### PR TITLE
Testing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import http from 'http';
 import { randomUUID } from 'crypto';
 import { getSupabaseClient, getRedisClient, closeAllConnections } from './db/client.js';
 import { VConQueries } from './db/queries.js';
-import { validateVCon, validateAnalysis } from './utils/validation.js';
+import { validateVCon, validateAnalysis, validateUUID } from './utils/validation.js';
 import {
   allTools,
   AnalysisSchema,
@@ -389,8 +389,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           purpose: args?.purpose as string | undefined,
         };
         
-        if (!uuid) {
-          throw new McpError(ErrorCode.InvalidParams, 'UUID is required');
+        const uuidValidation = validateUUID(uuid, 'uuid');
+        if (!uuidValidation.valid) {
+          throw new McpError(ErrorCode.InvalidParams, uuidValidation.errors.join(', '));
         }
 
         // Hook: beforeRead (can throw to block access)
@@ -759,8 +760,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const vconUuid = args?.vcon_uuid as string;
         const analysisData = args?.analysis;
 
-        if (!vconUuid) {
-          throw new McpError(ErrorCode.InvalidParams, 'vcon_uuid is required');
+        const uuidValidation = validateUUID(vconUuid, 'vcon_uuid');
+        if (!uuidValidation.valid) {
+          throw new McpError(ErrorCode.InvalidParams, uuidValidation.errors.join(', '));
         }
 
         if (!analysisData) {
@@ -814,8 +816,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const vconUuid = args?.vcon_uuid as string;
         const dialogData = args?.dialog;
 
-        if (!vconUuid) {
-          throw new McpError(ErrorCode.InvalidParams, 'vcon_uuid is required');
+        const uuidValidation = validateUUID(vconUuid, 'vcon_uuid');
+        if (!uuidValidation.valid) {
+          throw new McpError(ErrorCode.InvalidParams, uuidValidation.errors.join(', '));
         }
 
         if (!dialogData) {
@@ -852,8 +855,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const vconUuid = args?.vcon_uuid as string;
         const attachmentData = args?.attachment;
 
-        if (!vconUuid) {
-          throw new McpError(ErrorCode.InvalidParams, 'vcon_uuid is required');
+        const uuidValidation = validateUUID(vconUuid, 'vcon_uuid');
+        if (!uuidValidation.valid) {
+          throw new McpError(ErrorCode.InvalidParams, uuidValidation.errors.join(', '));
         }
 
         if (!attachmentData) {
@@ -893,8 +897,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           purpose: args?.purpose as string | undefined,
         };
         
-        if (!uuid) {
-          throw new McpError(ErrorCode.InvalidParams, 'UUID is required');
+        const uuidValidation = validateUUID(uuid, 'uuid');
+        if (!uuidValidation.valid) {
+          throw new McpError(ErrorCode.InvalidParams, uuidValidation.errors.join(', '));
         }
 
         // Hook: beforeDelete (can throw to prevent deletion)
@@ -933,8 +938,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const updates = args?.updates as Partial<VCon> | undefined;
         const returnUpdated = (args?.return_updated as boolean | undefined) ?? true;
 
-        if (!uuid) {
-          throw new McpError(ErrorCode.InvalidParams, 'UUID is required');
+        const uuidValidation = validateUUID(uuid, 'uuid');
+        if (!uuidValidation.valid) {
+          throw new McpError(ErrorCode.InvalidParams, uuidValidation.errors.join(', '));
         }
         if (!updates || typeof updates !== 'object') {
           throw new McpError(ErrorCode.InvalidParams, 'updates object is required');
@@ -1279,8 +1285,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const key = args?.key as string;
         const value = args?.value;
 
-        if (!vconUuid || !action || !key) {
-          throw new McpError(ErrorCode.InvalidParams, 'vcon_uuid, action, and key are required');
+        const uuidValidation = validateUUID(vconUuid, 'vcon_uuid');
+        if (!uuidValidation.valid) {
+          throw new McpError(ErrorCode.InvalidParams, uuidValidation.errors.join(', '));
+        }
+        
+        if (!action || !key) {
+          throw new McpError(ErrorCode.InvalidParams, 'action and key are required');
         }
 
         span.setAttributes({
@@ -1331,8 +1342,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const key = args?.key as string | undefined;
         const defaultValue = args?.default_value;
 
-        if (!vconUuid) {
-          throw new McpError(ErrorCode.InvalidParams, 'vcon_uuid is required');
+        const uuidValidation = validateUUID(vconUuid, 'vcon_uuid');
+        if (!uuidValidation.valid) {
+          throw new McpError(ErrorCode.InvalidParams, uuidValidation.errors.join(', '));
         }
 
         span.setAttributes({
@@ -1378,8 +1390,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'remove_all_tags': {
         const vconUuid = args?.vcon_uuid as string;
 
-        if (!vconUuid) {
-          throw new McpError(ErrorCode.InvalidParams, 'vcon_uuid is required');
+        const uuidValidation = validateUUID(vconUuid, 'vcon_uuid');
+        if (!uuidValidation.valid) {
+          throw new McpError(ErrorCode.InvalidParams, uuidValidation.errors.join(', '));
         }
 
         await queries.removeAllTags(vconUuid);

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,6 +438,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           partyTel: args?.party_tel as string | undefined,
           startDate: normalizeDateString(args?.start_date as string | undefined),
           endDate: normalizeDateString(args?.end_date as string | undefined),
+          tags: args?.tags as Record<string, string> | undefined,
           limit: (args?.limit as number | undefined) || 10,
         };
 
@@ -496,6 +497,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               partyTel: filters.partyTel,
               startDate: filters.startDate,
               endDate: filters.endDate,
+              tags: filters.tags,
             });
           } catch (countError: any) {
             // Log count error but don't fail the entire request

--- a/src/tools/tag-tools.ts
+++ b/src/tools/tag-tools.ts
@@ -36,7 +36,11 @@ export const manageTagTool = {
         description: 'Tag key/name (e.g., "department", "priority", "customer_id")'
       },
       value: {
-        type: ['string', 'number', 'boolean'],
+        oneOf: [
+          { type: 'string' },
+          { type: 'number' },
+          { type: 'boolean' }
+        ],
         description: 'Tag value (required when action is "set", will be converted to string)'
       }
     },
@@ -63,8 +67,14 @@ export const getTagsTool = {
         description: 'Specific tag key to retrieve. Omit this parameter to get all tags as an object.'
       },
       default_value: {
-        type: ['string', 'number', 'boolean', 'null'],
-        description: 'Value to return if the specified tag key does not exist (only used when key is provided, default: null)'
+        oneOf: [
+          { type: 'string' },
+          { type: 'number' },
+          { type: 'boolean' },
+          { type: 'null' }
+        ],
+        description: 'Value to return if the specified tag key does not exist (only used when key is provided, default: null)',
+        default: null
       }
     },
     required: ['vcon_uuid']
@@ -108,7 +118,8 @@ export const searchByTagsTool = {
         type: 'number',
         description: 'Maximum number of UUIDs to return (default: 50)',
         minimum: 1,
-        maximum: 100
+        maximum: 100,
+        default: 50
       },
       return_full_vcons: {
         type: 'boolean',

--- a/src/tools/vcon-crud.ts
+++ b/src/tools/vcon-crud.ts
@@ -167,7 +167,7 @@ export const getVConTool = {
  */
 export const searchVConsTool = {
   name: 'search_vcons',
-  description: 'Search for vCons using various criteria. Returns an array of matching vCons. ' +
+  description: 'Search for vCons using various criteria including tags. Returns an array of matching vCons. ' +
     'For full-text or semantic search of conversation content, use search_vcons_content instead. ' +
     '⚠️ LARGE DATABASE WARNING: Use response_format="metadata" for large result sets to avoid memory issues.',
   inputSchema: {
@@ -196,6 +196,11 @@ export const searchVConsTool = {
       end_date: {
         type: 'string',
         description: 'Filter by vCons created on or before this date (ISO 8601 format)'
+      },
+      tags: {
+        type: 'object',
+        description: 'Filter by tags (key-value pairs). Example: {"department": "sales", "priority": "high"}',
+        additionalProperties: { type: 'string' }
       },
       limit: {
         type: 'number',

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -295,6 +295,37 @@ export function validateAnalysis(analysis: Analysis): ValidationResult {
 }
 
 /**
+ * Validate UUID format
+ * Returns true if UUID matches standard format, false otherwise
+ */
+export function isValidUUID(uuid: string | undefined | null): boolean {
+  if (!uuid) return false;
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(uuid);
+}
+
+/**
+ * Validate UUID format and return validation result
+ * Use this in tool handlers for consistent validation
+ */
+export function validateUUID(uuid: string | undefined | null, paramName: string = 'uuid'): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  
+  if (!uuid) {
+    errors.push(`${paramName} is required`);
+  } else if (!isValidUUID(uuid)) {
+    errors.push(`Invalid ${paramName} format: "${uuid}". Expected UUID format (e.g., "550e8400-e29b-41d4-a716-446655440000")`);
+  }
+  
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings
+  };
+}
+
+/**
  * Validate Dialog type
  */
 export function validateDialog(dialog: Dialog): ValidationResult {

--- a/tests/new-tools-resources.test.ts
+++ b/tests/new-tools-resources.test.ts
@@ -1,14 +1,462 @@
-import { describe, it, expect } from 'vitest';
-import { VConQueries } from '../src/db/queries.js';
+/**
+ * Resources Endpoint Tests
+ * Tests for MCP resources endpoint (ListResources and ReadResource)
+ */
 
-describe('New tools and resources (smoke)', () => {
-  it('defines update_vcon tool schema in code', async () => {
-    expect(true).toBe(true);
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { VConQueries } from '../src/db/queries.js';
+import { getCoreResources, resolveCoreResource } from '../src/resources/index.js';
+import { VCon } from '../src/types/vcon.js';
+
+describe('Resources Endpoint Tests', () => {
+  let queries: VConQueries;
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    // Create a chainable mock that returns itself for all methods
+    const createChainableMock = () => {
+      const mock: any = {
+        from: vi.fn(),
+        select: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        eq: vi.fn(),
+        single: vi.fn(),
+        limit: vi.fn(),
+        order: vi.fn(),
+        ilike: vi.fn(),
+        gte: vi.fn(),
+        lte: vi.fn(),
+        or: vi.fn(),
+      };
+
+      // Make all methods return the mock itself for chaining
+      Object.keys(mock).forEach(key => {
+        if (key !== 'single') {
+          mock[key].mockReturnValue(mock);
+        }
+      });
+
+      return mock;
+    };
+
+    mockSupabase = createChainableMock();
+    queries = new VConQueries(mockSupabase);
   });
 
-  it('core resources list contains vcon://uuid/{uuid}', async () => {
-    expect(true).toBe(true);
+  describe('getCoreResources', () => {
+    it('should return all expected core resources', () => {
+      const resources = getCoreResources();
+
+      expect(resources).toHaveLength(5);
+      expect(resources.map(r => r.uri)).toEqual([
+        'vcon://recent',
+        'vcon://recent/ids',
+        'vcon://list/ids',
+        'vcon://uuid/{uuid}',
+        'vcon://uuid/{uuid}/metadata',
+      ]);
+    });
+
+    it('should return resources with correct structure', () => {
+      const resources = getCoreResources();
+
+      resources.forEach(resource => {
+        expect(resource).toHaveProperty('uri');
+        expect(resource).toHaveProperty('name');
+        expect(resource).toHaveProperty('description');
+        expect(resource).toHaveProperty('mimeType');
+        expect(resource.mimeType).toBe('application/json');
+        expect(typeof resource.uri).toBe('string');
+        expect(typeof resource.name).toBe('string');
+        expect(typeof resource.description).toBe('string');
+      });
+    });
+
+    it('should include vcon://uuid/{uuid} resource', () => {
+      const resources = getCoreResources();
+      const uuidResource = resources.find(r => r.uri === 'vcon://uuid/{uuid}');
+
+      expect(uuidResource).toBeDefined();
+      expect(uuidResource?.name).toBe('Get vCon by UUID');
+      expect(uuidResource?.mimeType).toBe('application/json');
+    });
+  });
+
+  describe('resolveCoreResource - Recent vCons', () => {
+    it('should return recent vCons with default limit of 10', async () => {
+      const mockVCons: VCon[] = Array.from({ length: 10 }, (_, i) => ({
+        vcon: '0.3.0',
+        uuid: `test-uuid-${i}`,
+        created_at: new Date().toISOString(),
+        subject: `Test vCon ${i}`,
+        parties: [],
+      }));
+
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue(mockVCons);
+
+      const result = await resolveCoreResource(queries, 'vcon://recent');
+
+      expect(result).toBeDefined();
+      expect(result?.mimeType).toBe('application/json');
+      expect(result?.content).toHaveProperty('count', 10);
+      expect(result?.content).toHaveProperty('limit', 10);
+      expect(result?.content).toHaveProperty('vcons');
+      expect(result?.content.vcons).toHaveLength(10);
+      expect(queries.searchVCons).toHaveBeenCalledWith({ limit: 10 });
+    });
+
+    it('should return recent vCons with custom limit', async () => {
+      const mockVCons: VCon[] = Array.from({ length: 25 }, (_, i) => ({
+        vcon: '0.3.0',
+        uuid: `test-uuid-${i}`,
+        created_at: new Date().toISOString(),
+        subject: `Test vCon ${i}`,
+        parties: [],
+      }));
+
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue(mockVCons);
+
+      const result = await resolveCoreResource(queries, 'vcon://recent/25');
+
+      expect(result).toBeDefined();
+      expect(result?.content).toHaveProperty('limit', 25);
+      expect(result?.content.vcons).toHaveLength(25);
+      expect(queries.searchVCons).toHaveBeenCalledWith({ limit: 25 });
+    });
+
+    it('should enforce max limit of 100', async () => {
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue([]);
+
+      resolveCoreResource(queries, 'vcon://recent/200');
+
+      expect(queries.searchVCons).toHaveBeenCalledWith({ limit: 100 });
+    });
+
+    it('should handle empty results', async () => {
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue([]);
+
+      const result = await resolveCoreResource(queries, 'vcon://recent');
+
+      expect(result).toBeDefined();
+      expect(result?.content).toHaveProperty('count', 0);
+      expect(result?.content.vcons).toHaveLength(0);
+    });
+  });
+
+  describe('resolveCoreResource - Recent vCon IDs', () => {
+    it('should return recent vCon IDs with default limit of 10', async () => {
+      const mockVCons: VCon[] = Array.from({ length: 10 }, (_, i) => ({
+        vcon: '0.3.0',
+        uuid: `test-uuid-${i}`,
+        created_at: new Date(Date.now() - i * 1000).toISOString(),
+        subject: `Test vCon ${i}`,
+        parties: [],
+      }));
+
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue(mockVCons);
+
+      const result = await resolveCoreResource(queries, 'vcon://recent/ids');
+
+      expect(result).toBeDefined();
+      expect(result?.mimeType).toBe('application/json');
+      expect(result?.content).toHaveProperty('count', 10);
+      expect(result?.content).toHaveProperty('limit', 10);
+      expect(result?.content).toHaveProperty('vcons');
+      expect(result?.content.vcons).toHaveLength(10);
+      
+      // Check that only uuid, created_at, and subject are included
+      result?.content.vcons.forEach((vcon: any) => {
+        expect(vcon).toHaveProperty('uuid');
+        expect(vcon).toHaveProperty('created_at');
+        expect(vcon).toHaveProperty('subject');
+        expect(vcon).not.toHaveProperty('parties');
+        expect(vcon).not.toHaveProperty('dialog');
+        expect(vcon).not.toHaveProperty('analysis');
+      });
+    });
+
+    it('should return recent vCon IDs with custom limit', async () => {
+      const mockVCons: VCon[] = Array.from({ length: 50 }, (_, i) => ({
+        vcon: '0.3.0',
+        uuid: `test-uuid-${i}`,
+        created_at: new Date().toISOString(),
+        subject: `Test vCon ${i}`,
+        parties: [],
+      }));
+
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue(mockVCons);
+
+      const result = await resolveCoreResource(queries, 'vcon://recent/ids/50');
+
+      expect(result).toBeDefined();
+      expect(result?.content).toHaveProperty('limit', 50);
+      expect(result?.content.vcons).toHaveLength(50);
+      expect(queries.searchVCons).toHaveBeenCalledWith({ limit: 50 });
+    });
+
+    it('should enforce max limit of 100 for recent IDs', async () => {
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue([]);
+
+      resolveCoreResource(queries, 'vcon://recent/ids/200');
+
+      expect(queries.searchVCons).toHaveBeenCalledWith({ limit: 100 });
+    });
+  });
+
+  describe('resolveCoreResource - List All IDs', () => {
+    it('should return list of IDs with default limit of 100', async () => {
+      const mockVCons: VCon[] = Array.from({ length: 100 }, (_, i) => ({
+        vcon: '0.3.0',
+        uuid: `test-uuid-${i}`,
+        created_at: new Date(Date.now() - i * 1000).toISOString(),
+        subject: `Test vCon ${i}`,
+        parties: [],
+      }));
+
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue(mockVCons);
+
+      const result = await resolveCoreResource(queries, 'vcon://list/ids');
+
+      expect(result).toBeDefined();
+      expect(result?.content).toHaveProperty('count', 100);
+      expect(result?.content).toHaveProperty('limit', 100);
+      expect(result?.content).toHaveProperty('has_more', false);
+      expect(result?.content).toHaveProperty('next_cursor', null);
+      expect(result?.content).toHaveProperty('vcons');
+      expect(queries.searchVCons).toHaveBeenCalledWith({ limit: 101 }); // Fetch one extra
+    });
+
+    it('should return list of IDs with custom limit', async () => {
+      const mockVCons: VCon[] = Array.from({ length: 500 }, (_, i) => ({
+        vcon: '0.3.0',
+        uuid: `test-uuid-${i}`,
+        created_at: new Date(Date.now() - i * 1000).toISOString(),
+        subject: `Test vCon ${i}`,
+        parties: [],
+      }));
+
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue(mockVCons);
+
+      const result = await resolveCoreResource(queries, 'vcon://list/ids/500');
+
+      expect(result).toBeDefined();
+      expect(result?.content).toHaveProperty('limit', 500);
+      expect(queries.searchVCons).toHaveBeenCalledWith({ limit: 501 }); // Fetch one extra
+    });
+
+    it('should enforce max limit of 1000', async () => {
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue([]);
+
+      resolveCoreResource(queries, 'vcon://list/ids/2000');
+
+      expect(queries.searchVCons).toHaveBeenCalledWith({ limit: 1001 }); // Fetch one extra
+    });
+
+    it('should indicate has_more when more results exist', async () => {
+      // Return 101 items to indicate more exist
+      const mockVCons: VCon[] = Array.from({ length: 101 }, (_, i) => ({
+        vcon: '0.3.0',
+        uuid: `test-uuid-${i}`,
+        created_at: new Date(Date.now() - i * 1000).toISOString(),
+        subject: `Test vCon ${i}`,
+        parties: [],
+      }));
+
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue(mockVCons);
+
+      const result = await resolveCoreResource(queries, 'vcon://list/ids/100');
+
+      expect(result).toBeDefined();
+      expect(result?.content).toHaveProperty('has_more', true);
+      expect(result?.content).toHaveProperty('next_cursor');
+      expect(result?.content.next_cursor).toBeTruthy();
+      expect(result?.content.vcons).toHaveLength(100); // Should return only 100
+    });
+
+    it('should handle pagination with after parameter', async () => {
+      const afterTimestamp = '2024-01-01T00:00:00Z';
+      const mockVCons: VCon[] = Array.from({ length: 50 }, (_, i) => ({
+        vcon: '0.3.0',
+        uuid: `test-uuid-${i}`,
+        created_at: new Date(Date.now() - i * 1000).toISOString(),
+        subject: `Test vCon ${i}`,
+        parties: [],
+      }));
+
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue(mockVCons);
+
+      const result = await resolveCoreResource(queries, `vcon://list/ids/50/after/${encodeURIComponent(afterTimestamp)}`);
+
+      expect(result).toBeDefined();
+      expect(queries.searchVCons).toHaveBeenCalledWith({
+        limit: 51,
+        startDate: expect.stringContaining('2024-01-01'),
+      });
+    });
+
+    it('should return null next_cursor when no more results', async () => {
+      const mockVCons: VCon[] = Array.from({ length: 50 }, (_, i) => ({
+        vcon: '0.3.0',
+        uuid: `test-uuid-${i}`,
+        created_at: new Date(Date.now() - i * 1000).toISOString(),
+        subject: `Test vCon ${i}`,
+        parties: [],
+      }));
+
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue(mockVCons);
+
+      const result = await resolveCoreResource(queries, 'vcon://list/ids/100');
+
+      expect(result).toBeDefined();
+      expect(result?.content).toHaveProperty('has_more', false);
+      expect(result?.content.next_cursor).toBeNull();
+    });
+  });
+
+  describe('resolveCoreResource - UUID-based Resources', () => {
+    const testUuid = '123e4567-e89b-12d3-a456-426614174000';
+    const mockVCon: VCon = {
+      vcon: '0.3.0',
+      uuid: testUuid,
+      created_at: '2024-01-01T00:00:00Z',
+      subject: 'Test vCon',
+      parties: [
+        { name: 'Alice', mailto: 'alice@example.com', uuid: 'party-uuid-1' },
+      ],
+      dialog: [
+        { type: 'text', body: 'Hello', encoding: 'none' },
+      ],
+      analysis: [
+        { type: 'summary', vendor: 'TestVendor', body: 'Summary', encoding: 'none' },
+      ],
+      attachments: [
+        { type: 'document', body: 'attachment', encoding: 'none' },
+      ],
+    };
+
+    it('should return full vCon by UUID', async () => {
+      vi.spyOn(queries, 'getVCon').mockResolvedValue(mockVCon);
+
+      const result = await resolveCoreResource(queries, `vcon://uuid/${testUuid}`);
+
+      expect(result).toBeDefined();
+      expect(result?.mimeType).toBe('application/json');
+      expect(result?.content).toEqual(mockVCon);
+      expect(queries.getVCon).toHaveBeenCalledWith(testUuid);
+    });
+
+    it('should return full vCon by UUID with trailing slash', async () => {
+      vi.spyOn(queries, 'getVCon').mockResolvedValue(mockVCon);
+
+      const result = await resolveCoreResource(queries, `vcon://uuid/${testUuid}/`);
+
+      expect(result).toBeDefined();
+      expect(result?.content).toEqual(mockVCon);
+    });
+
+    it('should return metadata only for metadata endpoint', async () => {
+      vi.spyOn(queries, 'getVCon').mockResolvedValue(mockVCon);
+
+      const result = await resolveCoreResource(queries, `vcon://uuid/${testUuid}/metadata`);
+
+      expect(result).toBeDefined();
+      expect(result?.mimeType).toBe('application/json');
+      expect(result?.content).toHaveProperty('vcon');
+      expect(result?.content).toHaveProperty('uuid');
+      expect(result?.content).toHaveProperty('created_at');
+      expect(result?.content).toHaveProperty('subject');
+      expect(result?.content).not.toHaveProperty('parties');
+      expect(result?.content).not.toHaveProperty('dialog');
+      expect(result?.content).not.toHaveProperty('analysis');
+      expect(result?.content).not.toHaveProperty('attachments');
+    });
+
+    it('should return undefined for invalid UUID format', async () => {
+      vi.spyOn(queries, 'getVCon');
+      
+      const result = await resolveCoreResource(queries, 'vcon://uuid/invalid-uuid');
+
+      expect(result).toBeUndefined();
+      expect(queries.getVCon).not.toHaveBeenCalled();
+    });
+
+    it('should return undefined for unsupported UUID suffix', async () => {
+      vi.spyOn(queries, 'getVCon').mockResolvedValue(mockVCon);
+
+      const result = await resolveCoreResource(queries, `vcon://uuid/${testUuid}/unsupported`);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('resolveCoreResource - Error Cases', () => {
+    it('should return undefined for unknown URI', async () => {
+      const result = await resolveCoreResource(queries, 'vcon://unknown/resource');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for invalid URI format', async () => {
+      const result = await resolveCoreResource(queries, 'not-a-valid-uri');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle database errors gracefully', async () => {
+      vi.spyOn(queries, 'searchVCons').mockRejectedValue(new Error('Database error'));
+
+      await expect(
+        resolveCoreResource(queries, 'vcon://recent')
+      ).rejects.toThrow('Database error');
+    });
+
+    it('should handle getVCon errors gracefully', async () => {
+      const testUuid = '123e4567-e89b-12d3-a456-426614174000';
+      vi.spyOn(queries, 'getVCon').mockRejectedValue(new Error('vCon not found'));
+
+      await expect(
+        resolveCoreResource(queries, `vcon://uuid/${testUuid}`)
+      ).rejects.toThrow('vCon not found');
+    });
+  });
+
+  describe('Resource Response Format', () => {
+    it('should return JSON mime type for all resources', async () => {
+      const mockVCon: VCon = {
+        vcon: '0.3.0',
+        uuid: '123e4567-e89b-12d3-a456-426614174000',
+        created_at: new Date().toISOString(),
+        subject: 'Test',
+        parties: [],
+      };
+
+      vi.spyOn(queries, 'searchVCons').mockResolvedValue([mockVCon]);
+      vi.spyOn(queries, 'getVCon').mockResolvedValue(mockVCon);
+
+      const recentResult = await resolveCoreResource(queries, 'vcon://recent');
+      const uuidResult = await resolveCoreResource(queries, 'vcon://uuid/123e4567-e89b-12d3-a456-426614174000');
+
+      expect(recentResult?.mimeType).toBe('application/json');
+      expect(uuidResult?.mimeType).toBe('application/json');
+    });
+
+    it('should format content as JSON-serializable objects', async () => {
+      const mockVCon: VCon = {
+        vcon: '0.3.0',
+        uuid: '123e4567-e89b-12d3-a456-426614174000',
+        created_at: new Date().toISOString(),
+        subject: 'Test',
+        parties: [],
+      };
+
+      vi.spyOn(queries, 'getVCon').mockResolvedValue(mockVCon);
+
+      const result = await resolveCoreResource(queries, 'vcon://uuid/123e4567-e89b-12d3-a456-426614174000');
+
+      // Should be able to JSON.stringify without errors
+      expect(() => JSON.stringify(result?.content)).not.toThrow();
+    });
   });
 });
-
-

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     setupFiles: ['dotenv/config'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/**/*.d.ts', 'node_modules/**'],
+    },
   },
 });
 


### PR DESCRIPTION
This pull request introduces several improvements to both the codebase and documentation, focusing on standardizing validation, error handling, response formats, and enhancing tag-based search functionality for vCons. The changes ensure that all tools follow consistent best practices, particularly around input validation (with a new UUID validator), JSON Schema compliance, and error messaging. Additionally, the search and counting logic in the database layer now supports tag-based filtering.

The most important changes are:

**Validation and Error Handling Improvements**
- Implemented a two-layer validation strategy: JSON Schema validation at the protocol level and runtime validation in tool handlers. Introduced and enforced the use of a `validateUUID()` helper for consistent UUID validation across all relevant tool handlers. Standardized error messages to be clear, actionable, and include parameter names, with guidelines for using specific error codes. [[1]](diffhunk://#diff-339aa04f9e54c6299b87ae143e064f50b18287665d2a7a0bb599c8f3300d0d06L675-R769) [[2]](diffhunk://#diff-339aa04f9e54c6299b87ae143e064f50b18287665d2a7a0bb599c8f3300d0d06L705-R897) [[3]](diffhunk://#diff-339aa04f9e54c6299b87ae143e064f50b18287665d2a7a0bb599c8f3300d0d06L736-R974) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L392-R394) [[5]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L760-R765) [[6]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L815-R821) [[7]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L853-R860) [[8]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L894-R902) [[9]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L934-R943) [[10]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1280-R1294) [[11]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1332-R1347) [[12]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1379-R1395)

**JSON Schema and Tool Input Improvements**
- Updated all tool input schemas to use valid JSON Schema, replacing invalid union type array syntax with `oneOf`/`anyOf`, and ensuring that default values are explicitly specified in the schema when mentioned in descriptions. [[1]](diffhunk://#diff-ba746c6a000a9487952f8c0eee34e551ec72b57d0c7f7e820e5548b02bb1dacaL39-R43) [[2]](diffhunk://#diff-ba746c6a000a9487952f8c0eee34e551ec72b57d0c7f7e820e5548b02bb1dacaL66-R77) [[3]](diffhunk://#diff-ba746c6a000a9487952f8c0eee34e551ec72b57d0c7f7e820e5548b02bb1dacaL111-R122) [[4]](diffhunk://#diff-339aa04f9e54c6299b87ae143e064f50b18287665d2a7a0bb599c8f3300d0d06L675-R769)

**Response Format Standardization**
- Documented and enforced a standard response format for all tools, requiring a `success` field and a consistent structure for both success and error responses. [[1]](diffhunk://#diff-339aa04f9e54c6299b87ae143e064f50b18287665d2a7a0bb599c8f3300d0d06L705-R897) [[2]](diffhunk://#diff-339aa04f9e54c6299b87ae143e064f50b18287665d2a7a0bb599c8f3300d0d06L736-R974)

**Tag-Based Search and Count Enhancements**
- Added support for tag-based filtering in vCon search and count queries, updating both the `VConQueries` methods and the tool input parameters to accept tag filters. The logic ensures intersection of tag matches with other filters. [[1]](diffhunk://#diff-b4e8a5167246787e6ee0cab1815ff97079643cfa6a80ec895596f00be8d60668R702) [[2]](diffhunk://#diff-b4e8a5167246787e6ee0cab1815ff97079643cfa6a80ec895596f00be8d60668R784-R790) [[3]](diffhunk://#diff-b4e8a5167246787e6ee0cab1815ff97079643cfa6a80ec895596f00be8d60668R808) [[4]](diffhunk://#diff-b4e8a5167246787e6ee0cab1815ff97079643cfa6a80ec895596f00be8d60668R873-R905) [[5]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R442) [[6]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R501) [[7]](diffhunk://#diff-40ba671f170b7bd85dbf32d528eb101454439cb9cd575e4fda510af6bdb0776fL170-R170)

**Documentation Updates**
- Expanded the custom tools development guide with sections on validation strategy, response format standardization, error message consistency, and a summary checklist for tool authors. [[1]](diffhunk://#diff-339aa04f9e54c6299b87ae143e064f50b18287665d2a7a0bb599c8f3300d0d06L675-R769) [[2]](diffhunk://#diff-339aa04f9e54c6299b87ae143e064f50b18287665d2a7a0bb599c8f3300d0d06L705-R897) [[3]](diffhunk://#diff-339aa04f9e54c6299b87ae143e064f50b18287665d2a7a0bb599c8f3300d0d06L736-R974)

These changes collectively improve the reliability, maintainability, and developer experience for both tool authors and users of the MCP platform.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tag-based filtering to vCon search/count, enforces UUID validation across handlers, standardizes JSON Schemas/responses, and expands docs/tests.
> 
> - **Server/Handlers (`src/index.ts`)**:
>   - Enforce UUID validation via `validateUUID()` for `get_vcon`, `add_analysis`, `add_dialog`, `add_attachment`, `delete_vcon`, `update_vcon`, and tag tools.
>   - Extend `search_vcons` to accept `tags` and pass to count; improved DB error messaging.
> - **DB Layer (`src/db/queries.ts`)**:
>   - Add `tags` filter support to `searchVCons` and `searchVConsCount` with intersection logic; integrate `searchByTags`.
> - **Tools/Schemas**:
>   - `src/tools/vcon-crud.ts`: `search_vcons` now supports `tags`.
>   - `src/tools/tag-tools.ts`: Replace invalid union types with `oneOf`; add schema defaults (e.g., `limit`); keep UUID patterns.
> - **Validation (`src/utils/validation.ts`)**:
>   - New `isValidUUID()` and `validateUUID()` helpers; exported and used across handlers.
> - **Documentation (`docs/development/custom-tools.md`)**:
>   - Add sections for validation strategy, response format standardization, and error message consistency; include examples and checklist.
> - **Tests**:
>   - Add/expand tests for tag-filtered search/count, resources endpoints, and limits (`tests/*.test.ts`).
>   - Enable coverage in `vitest.config.ts` (v8, reporters).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9067e216152784d24af12401ad7011e570d42538. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->