### PR TITLE
Add embedded media handling for vCon import with S3 externalization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.922.0",
         "@aws-sdk/credential-providers": "^3.927.0",
+        "@aws-sdk/s3-request-presigner": "^3.922.0",
         "@modelcontextprotocol/sdk": "^1.19.1",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.48.0",
@@ -1800,6 +1801,118 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.948.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.948.0.tgz",
+      "integrity": "sha512-tlQhMDsDWwUDUzzlo8XYGpmMfjGDmXgbysv1+h1v2xJe0A+ogv/nJ6KFVP94uf1j4ePmCN/gDdxEp2PWZMBPOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.947.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-format-url": "3.936.0",
+        "@smithy/middleware-endpoint": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/core": {
+      "version": "3.947.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.947.0.tgz",
+      "integrity": "sha512-Khq4zHhuAkvCFuFbgcy3GrZTzfSX7ZIjIcW1zRDxXRLZKRtuhnZdonqTUfaWi5K42/4OmxkYNpsO7X7trQOeHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.7",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.947.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.947.0.tgz",
+      "integrity": "sha512-DS2tm5YBKhPW2PthrRBDr6eufChbwXe0NjtTZcYDfUCXf0OR+W6cIqyKguwHMJ+IyYdey30AfVw9/Lb5KB8U8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.947.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/core": "^3.18.7",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.10",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.947.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.947.0.tgz",
+      "integrity": "sha512-UaYmzoxf9q3mabIA2hc4T6x5YSFUG2BpNjAZ207EA1bnQMiK+d6vZvb83t7dIWL/U1de1sGV19c1C81Jf14rrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.947.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/types": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.922.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.922.0.tgz",
@@ -1870,6 +1983,34 @@
         "@smithy/types": "^4.8.1",
         "@smithy/url-parser": "^4.2.4",
         "@smithy/util-endpoints": "^3.2.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.936.0.tgz",
+      "integrity": "sha512-MS5eSEtDUFIAMHrJaMERiHAvDPdfxc/T869ZjDNFAIiZhyc037REw0aoTNeimNXDNy2txRNZJaAUn/kE4RwN+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4980,12 +5121,12 @@
       "license": "MIT"
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.4.tgz",
-      "integrity": "sha512-Z4DUr/AkgyFf1bOThW2HwzREagee0sB5ycl+hDiSZOfRLW8ZgrOjDi6g8mHH19yyU5E2A/64W3z6SMIf5XiUSQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
+      "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.1",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5035,18 +5176,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.2.tgz",
-      "integrity": "sha512-n3g4Nl1Te+qGPDbNFAYf+smkRVB+JhFsGy9uJXXZQEufoP4u0r+WLh6KvTDolCswaagysDc/afS1yvb2jnj1gQ==",
+      "version": "3.18.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.7.tgz",
+      "integrity": "sha512-axG9MvKhMWOhFbvf5y2DuyTxQueO0dkedY9QC3mAfndLosRI/9LJv8WaL0mw7ubNhsO4IuXX9/9dYGPFvHrqlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/types": "^4.8.1",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.4",
-        "@smithy/util-stream": "^4.5.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
         "@smithy/util-utf8": "^4.2.0",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
@@ -5142,14 +5283,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.5.tgz",
-      "integrity": "sha512-mg83SM3FLI8Sa2ooTJbsh5MFfyMTyNRwxqpKHmE0ICRIa66Aodv80DMsTQI02xBLVJ0hckwqTRr5IGAbbWuFLQ==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
+      "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/querystring-builder": "^4.2.4",
-        "@smithy/types": "^4.8.1",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
@@ -5255,18 +5396,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.6.tgz",
-      "integrity": "sha512-PXehXofGMFpDqr933rxD8RGOcZ0QBAWtuzTgYRAHAL2BnKawHDEdf/TnGpcmfPJGwonhginaaeJIKluEojiF/w==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.14.tgz",
+      "integrity": "sha512-v0q4uTKgBM8dsqGjqsabZQyH85nFaTnFcgpWU1uydKFsdyyMzfvOkNum9G7VK+dOP01vUnoZxIeRiJ6uD0kjIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.17.2",
-        "@smithy/middleware-serde": "^4.2.4",
-        "@smithy/node-config-provider": "^4.3.4",
-        "@smithy/shared-ini-file-loader": "^4.3.4",
-        "@smithy/types": "^4.8.1",
-        "@smithy/url-parser": "^4.2.4",
-        "@smithy/util-middleware": "^4.2.4",
+        "@smithy/core": "^3.18.7",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-middleware": "^4.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5294,13 +5435,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.4.tgz",
-      "integrity": "sha512-jUr3x2CDhV15TOX2/Uoz4gfgeqLrRoTQbYAuhLS7lcVKNev7FeYSJ1ebEfjk+l9kbb7k7LfzIR/irgxys5ZTOg==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
+      "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/types": "^4.8.1",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5308,12 +5449,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.4.tgz",
-      "integrity": "sha512-Gy3TKCOnm9JwpFooldwAboazw+EFYlC+Bb+1QBsSi5xI0W5lX81j/P5+CXvD/9ZjtYKRgxq+kkqd/KOHflzvgA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
+      "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.1",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5321,14 +5462,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.4.tgz",
-      "integrity": "sha512-3X3w7qzmo4XNNdPKNS4nbJcGSwiEMsNsRSunMA92S4DJLLIrH5g1AyuOA2XKM9PAPi8mIWfqC+fnfKNsI4KvHw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
+      "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.4",
-        "@smithy/shared-ini-file-loader": "^4.3.4",
-        "@smithy/types": "^4.8.1",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5336,15 +5477,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.4.tgz",
-      "integrity": "sha512-VXHGfzCXLZeKnFp6QXjAdy+U8JF9etfpUXD1FAbzY1GzsFJiDQRQIt2CnMUvUdz3/YaHNqT3RphVWMUpXTIODA==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
+      "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/querystring-builder": "^4.2.4",
-        "@smithy/types": "^4.8.1",
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5352,12 +5493,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.4.tgz",
-      "integrity": "sha512-g2DHo08IhxV5GdY3Cpt/jr0mkTlAD39EJKN27Jb5N8Fb5qt8KG39wVKTXiTRCmHHou7lbXR8nKVU14/aRUf86w==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
+      "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.1",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5365,12 +5506,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.4.tgz",
-      "integrity": "sha512-3sfFd2MAzVt0Q/klOmjFi3oIkxczHs0avbwrfn1aBqtc23WqQSmjvk77MBw9WkEQcwbOYIX5/2z4ULj8DuxSsw==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
+      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.1",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5378,12 +5519,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.4.tgz",
-      "integrity": "sha512-KQ1gFXXC+WsbPFnk7pzskzOpn4s+KheWgO3dzkIEmnb6NskAIGp/dGdbKisTPJdtov28qNDohQrgDUKzXZBLig==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
+      "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.1",
+        "@smithy/types": "^4.9.0",
         "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -5392,12 +5533,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.4.tgz",
-      "integrity": "sha512-aHb5cqXZocdzEkZ/CvhVjdw5l4r1aU/9iMEyoKzH4eXMowT6M0YjBpp7W/+XjkBnY8Xh0kVd55GKjnPKlCwinQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
+      "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.1",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5417,12 +5558,12 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.4.tgz",
-      "integrity": "sha512-y5ozxeQ9omVjbnJo9dtTsdXj9BEvGx2X8xvRgKnV+/7wLBuYJQL6dOa/qMY6omyHi7yjt1OA97jZLoVRYi8lxA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
+      "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.1",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5430,16 +5571,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.4.tgz",
-      "integrity": "sha512-ScDCpasxH7w1HXHYbtk3jcivjvdA1VICyAdgvVqKhKKwxi+MTwZEqFw0minE+oZ7F07oF25xh4FGJxgqgShz0A==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
+      "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/types": "^4.8.1",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.4",
+        "@smithy/util-middleware": "^4.2.5",
         "@smithy/util-uri-escape": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
@@ -5449,17 +5590,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.2.tgz",
-      "integrity": "sha512-gZU4uAFcdrSi3io8U99Qs/FvVdRxPvIMToi+MFfsy/DN9UqtknJ1ais+2M9yR8e0ASQpNmFYEKeIKVcMjQg3rg==",
+      "version": "4.9.10",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.10.tgz",
+      "integrity": "sha512-Jaoz4Jw1QYHc1EFww/E6gVtNjhoDU+gwRKqXP6C3LKYqqH2UQhP8tMP3+t/ePrhaze7fhLE8vS2q6vVxBANFTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.17.2",
-        "@smithy/middleware-endpoint": "^4.3.6",
-        "@smithy/middleware-stack": "^4.2.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/types": "^4.8.1",
-        "@smithy/util-stream": "^4.5.5",
+        "@smithy/core": "^3.18.7",
+        "@smithy/middleware-endpoint": "^4.3.14",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5467,9 +5608,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.1.tgz",
-      "integrity": "sha512-N0Zn0OT1zc+NA+UVfkYqQzviRh5ucWwO7mBV3TmHHprMnfcJNfhlPicDkBHi0ewbh+y3evR6cNAW0Raxvb01NA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
+      "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5479,13 +5620,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.4.tgz",
-      "integrity": "sha512-w/N/Iw0/PTwJ36PDqU9PzAwVElo4qXxCC0eCTlUtIz/Z5V/2j/cViMHi0hPukSBHp4DVwvUlUhLgCzqSJ6plrg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
+      "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.4",
-        "@smithy/types": "^4.8.1",
+        "@smithy/querystring-parser": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5615,12 +5756,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.4.tgz",
-      "integrity": "sha512-fKGQAPAn8sgV0plRikRVo6g6aR0KyKvgzNrPuM74RZKy/wWVzx3BMk+ZWEueyN3L5v5EDg+P582mKU+sH5OAsg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
+      "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.1",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5642,14 +5783,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.5.tgz",
-      "integrity": "sha512-7M5aVFjT+HPilPOKbOmQfCIPchZe4DSBc1wf1+NvHvSoFTiFtauZzT+onZvCj70xhXd0AEmYnZYmdJIuwxOo4w==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
+      "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.5",
-        "@smithy/node-http-handler": "^4.4.4",
-        "@smithy/types": "^4.8.1",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/types": "^4.9.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-hex-encoding": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vcon-mcp",
-  "version": "1.0.4",
+  "version": "1.1.2",
   "description": "MCP Server for IETF vCon - Open Source Core",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.922.0",
     "@aws-sdk/credential-providers": "^3.927.0",
+    "@aws-sdk/s3-request-presigner": "^3.922.0",
     "@modelcontextprotocol/sdk": "^1.19.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.48.0",

--- a/scripts/load-legacy-vcons.ts
+++ b/scripts/load-legacy-vcons.ts
@@ -852,9 +852,7 @@ async function processVConFile(
                              (rawVcon.analysis && rawVcon.analysis.some((a: any) => a.encoding === 'text'));
 
       // Check if media handling is needed
-      const hasMedia = rawVcon.dialog && rawVcon.dialog.some((d: any) =>
-        d.type === 'recording' && d.body && d.encoding === 'base64url'
-      );
+      const hasMedia = rawVcon.dialog && hasEmbeddedMedia(rawVcon.dialog);
       const mediaHandling = options.mediaHandling || 'strip';
 
       let vcon: VCon;

--- a/scripts/load-legacy-vcons.ts
+++ b/scripts/load-legacy-vcons.ts
@@ -455,9 +455,6 @@ async function migrateVConWithMedia(
     };
 
     // Create S3 client for externalization
-    if (mediaHandling === 'externalize' && mediaStorage) {
-      mediaOptions.s3Client = undefined; // MediaStorage has its own client
-    }
 
     const { dialogs, stats } = await processDialogsForMedia(
       migratedVCon.dialog,

--- a/src/utils/media-storage.ts
+++ b/src/utils/media-storage.ts
@@ -78,8 +78,11 @@ export interface MediaProcessingOptions {
  * Check if a dialog contains embedded media that should be externalized
  */
 export function hasEmbeddedMedia(dialog: Dialog): boolean {
-  // Must have body and base64url encoding
-  if (!dialog.body || dialog.encoding !== 'base64url') {
+  // Must have body and base64/base64url encoding
+  if (
+    !dialog.body ||
+    (dialog.encoding !== 'base64' && dialog.encoding !== 'base64url')
+  ) {
     return false;
   }
 

--- a/src/utils/media-storage.ts
+++ b/src/utils/media-storage.ts
@@ -1,0 +1,394 @@
+/**
+ * Media Storage Utility for vCon Dialog Externalization
+ *
+ * Provides functionality to:
+ * - Detect embedded media in vCon dialogs (base64-encoded recordings)
+ * - Upload media to S3 with content-type detection
+ * - Generate presigned URLs for secure access
+ * - Update dialog objects to use external URLs
+ *
+ * Per IETF vcon-core-01 spec:
+ * - Dialog content can be inline (body + encoding) or external (url + content_hash)
+ * - HTTPS MUST be used for retrieval to protect privacy
+ * - content_hash SHOULD be provided for integrity verification
+ */
+
+import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { createHash } from 'crypto';
+import type { Dialog, Encoding } from '../types/vcon.js';
+
+/**
+ * Media types that indicate embedded recordings
+ */
+const MEDIA_MIMETYPES = [
+  'audio/',
+  'video/',
+  'application/ogg',
+  'application/octet-stream'
+];
+
+/**
+ * Configuration for media storage
+ */
+export interface MediaStorageConfig {
+  /** S3 bucket for media storage */
+  bucket: string;
+  /** Optional prefix for S3 keys (e.g., 'media/' or 'recordings/') */
+  prefix?: string;
+  /** AWS region */
+  region?: string;
+  /** Presigned URL expiration in seconds (default: 7 days) */
+  presignedUrlExpiration?: number;
+  /** Whether to generate presigned URLs (true) or use direct S3 URLs (false) */
+  usePresignedUrls?: boolean;
+}
+
+/**
+ * Result of media externalization
+ */
+export interface MediaExternalizationResult {
+  /** The updated dialog with url instead of body */
+  dialog: Dialog;
+  /** Whether media was externalized */
+  externalized: boolean;
+  /** S3 key where media was stored */
+  s3Key?: string;
+  /** Size of the media in bytes */
+  sizeBytes?: number;
+  /** Error message if externalization failed */
+  error?: string;
+}
+
+/**
+ * Options for processing dialogs with embedded media
+ */
+export interface MediaProcessingOptions {
+  /** How to handle embedded media */
+  mediaHandling: 'keep' | 'strip' | 'externalize';
+  /** S3 configuration (required if mediaHandling is 'externalize') */
+  s3Config?: MediaStorageConfig;
+  /** S3 client instance (optional, will be created if not provided) */
+  s3Client?: S3Client;
+  /** Minimum size in bytes to consider for externalization (default: 1024) */
+  minSizeBytes?: number;
+}
+
+/**
+ * Check if a dialog contains embedded media that should be externalized
+ */
+export function hasEmbeddedMedia(dialog: Dialog): boolean {
+  // Must have body and base64url encoding
+  if (!dialog.body || dialog.encoding !== 'base64url') {
+    return false;
+  }
+
+  // Must be a recording type
+  if (dialog.type !== 'recording') {
+    return false;
+  }
+
+  // Check mediatype if present
+  if (dialog.mediatype) {
+    return MEDIA_MIMETYPES.some(prefix => dialog.mediatype!.startsWith(prefix));
+  }
+
+  // If no mediatype but has base64url body in a recording dialog, assume it's media
+  return true;
+}
+
+/**
+ * Estimate the size of base64-encoded content in bytes
+ */
+export function estimateBase64Size(base64String: string): number {
+  // Remove padding
+  const padding = (base64String.match(/=/g) || []).length;
+  // Base64 encodes 3 bytes in 4 characters
+  return Math.floor((base64String.length * 3) / 4) - padding;
+}
+
+/**
+ * Decode base64url to Buffer
+ */
+export function decodeBase64Url(base64url: string): Buffer {
+  // Convert base64url to standard base64
+  let base64 = base64url
+    .replace(/-/g, '+')
+    .replace(/_/g, '/');
+
+  // Add padding if needed
+  while (base64.length % 4) {
+    base64 += '=';
+  }
+
+  return Buffer.from(base64, 'base64');
+}
+
+/**
+ * Compute SHA-256 hash of content (for content_hash field)
+ */
+export function computeContentHash(content: Buffer): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * Get file extension from mediatype
+ */
+function getExtensionFromMediatype(mediatype: string): string {
+  const typeMap: Record<string, string> = {
+    'audio/wav': 'wav',
+    'audio/x-wav': 'wav',
+    'audio/wave': 'wav',
+    'audio/mp3': 'mp3',
+    'audio/mpeg': 'mp3',
+    'audio/x-mp3': 'mp3',
+    'audio/ogg': 'ogg',
+    'audio/webm': 'webm',
+    'audio/aac': 'aac',
+    'audio/flac': 'flac',
+    'video/mp4': 'mp4',
+    'video/x-mp4': 'mp4',
+    'video/webm': 'webm',
+    'video/ogg': 'ogv',
+    'video/quicktime': 'mov',
+    'application/ogg': 'ogg',
+  };
+
+  return typeMap[mediatype] || mediatype.split('/')[1] || 'bin';
+}
+
+/**
+ * Media Storage class for handling S3 uploads and presigned URLs
+ */
+export class MediaStorage {
+  private s3Client: S3Client;
+  private config: Required<MediaStorageConfig>;
+
+  constructor(config: MediaStorageConfig, s3Client?: S3Client) {
+    this.config = {
+      bucket: config.bucket,
+      prefix: config.prefix || 'media/',
+      region: config.region || process.env.AWS_REGION || 'us-east-1',
+      presignedUrlExpiration: config.presignedUrlExpiration || 7 * 24 * 60 * 60, // 7 days
+      usePresignedUrls: config.usePresignedUrls ?? true,
+    };
+
+    this.s3Client = s3Client || new S3Client({ region: this.config.region });
+  }
+
+  /**
+   * Generate S3 key for a dialog's media content
+   */
+  generateS3Key(vconUuid: string, dialogIndex: number, mediatype?: string, filename?: string): string {
+    const ext = filename
+      ? filename.split('.').pop() || 'bin'
+      : mediatype
+        ? getExtensionFromMediatype(mediatype)
+        : 'bin';
+
+    // Use date-based partitioning for efficient storage
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+
+    return `${this.config.prefix}${year}/${month}/${day}/${vconUuid}/dialog-${dialogIndex}.${ext}`;
+  }
+
+  /**
+   * Upload media content to S3
+   */
+  async uploadMedia(
+    content: Buffer,
+    s3Key: string,
+    mediatype?: string
+  ): Promise<{ url: string; contentHash: string }> {
+    const contentHash = computeContentHash(content);
+
+    const command = new PutObjectCommand({
+      Bucket: this.config.bucket,
+      Key: s3Key,
+      Body: content,
+      ContentType: mediatype || 'application/octet-stream',
+      // Add metadata for integrity verification
+      Metadata: {
+        'content-hash': contentHash,
+      },
+    });
+
+    await this.s3Client.send(command);
+
+    // Generate URL
+    let url: string;
+    if (this.config.usePresignedUrls) {
+      url = await this.generatePresignedUrl(s3Key);
+    } else {
+      url = `https://${this.config.bucket}.s3.${this.config.region}.amazonaws.com/${s3Key}`;
+    }
+
+    return { url, contentHash };
+  }
+
+  /**
+   * Generate a presigned URL for accessing media
+   */
+  async generatePresignedUrl(s3Key: string): Promise<string> {
+    const command = new GetObjectCommand({
+      Bucket: this.config.bucket,
+      Key: s3Key,
+    });
+
+    return getSignedUrl(this.s3Client, command, {
+      expiresIn: this.config.presignedUrlExpiration,
+    });
+  }
+
+  /**
+   * Externalize a dialog's embedded media to S3
+   */
+  async externalizeDialog(
+    dialog: Dialog,
+    vconUuid: string,
+    dialogIndex: number
+  ): Promise<MediaExternalizationResult> {
+    if (!hasEmbeddedMedia(dialog)) {
+      return { dialog, externalized: false };
+    }
+
+    try {
+      // Decode the base64url content
+      const content = decodeBase64Url(dialog.body!);
+      const sizeBytes = content.length;
+
+      // Generate S3 key
+      const s3Key = this.generateS3Key(vconUuid, dialogIndex, dialog.mediatype, dialog.filename);
+
+      // Upload to S3
+      const { url, contentHash } = await this.uploadMedia(content, s3Key, dialog.mediatype);
+
+      // Create updated dialog with URL instead of body
+      const updatedDialog: Dialog = {
+        ...dialog,
+        url,
+        content_hash: contentHash,
+      };
+
+      // Remove body and encoding (now external)
+      delete updatedDialog.body;
+      delete updatedDialog.encoding;
+
+      return {
+        dialog: updatedDialog,
+        externalized: true,
+        s3Key,
+        sizeBytes,
+      };
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      return {
+        dialog,
+        externalized: false,
+        error: `Failed to externalize media: ${errorMsg}`,
+      };
+    }
+  }
+}
+
+/**
+ * Process dialogs according to media handling options
+ *
+ * @param dialogs - Array of dialog objects to process
+ * @param vconUuid - UUID of the vCon containing these dialogs
+ * @param options - Media processing options
+ * @returns Processed dialogs and statistics
+ */
+export async function processDialogsForMedia(
+  dialogs: Dialog[] | undefined,
+  vconUuid: string,
+  options: MediaProcessingOptions
+): Promise<{
+  dialogs: Dialog[];
+  stats: {
+    total: number;
+    withEmbeddedMedia: number;
+    stripped: number;
+    externalized: number;
+    externalizedBytes: number;
+    errors: string[];
+  };
+}> {
+  const stats = {
+    total: dialogs?.length || 0,
+    withEmbeddedMedia: 0,
+    stripped: 0,
+    externalized: 0,
+    externalizedBytes: 0,
+    errors: [] as string[],
+  };
+
+  if (!dialogs || dialogs.length === 0) {
+    return { dialogs: [], stats };
+  }
+
+  const minSize = options.minSizeBytes ?? 1024;
+  const processedDialogs: Dialog[] = [];
+
+  // Create MediaStorage if externalizing
+  let mediaStorage: MediaStorage | undefined;
+  if (options.mediaHandling === 'externalize' && options.s3Config) {
+    mediaStorage = new MediaStorage(options.s3Config, options.s3Client);
+  }
+
+  for (let i = 0; i < dialogs.length; i++) {
+    const dialog = dialogs[i];
+
+    if (!hasEmbeddedMedia(dialog)) {
+      processedDialogs.push(dialog);
+      continue;
+    }
+
+    stats.withEmbeddedMedia++;
+    const estimatedSize = estimateBase64Size(dialog.body!);
+
+    // Skip small media files
+    if (estimatedSize < minSize) {
+      processedDialogs.push(dialog);
+      continue;
+    }
+
+    switch (options.mediaHandling) {
+      case 'keep':
+        processedDialogs.push(dialog);
+        break;
+
+      case 'strip':
+        // Remove body but keep metadata
+        const strippedDialog: Dialog = { ...dialog };
+        delete strippedDialog.body;
+        delete strippedDialog.encoding;
+        processedDialogs.push(strippedDialog);
+        stats.stripped++;
+        break;
+
+      case 'externalize':
+        if (mediaStorage) {
+          const result = await mediaStorage.externalizeDialog(dialog, vconUuid, i);
+          processedDialogs.push(result.dialog);
+
+          if (result.externalized) {
+            stats.externalized++;
+            stats.externalizedBytes += result.sizeBytes || 0;
+          } else if (result.error) {
+            stats.errors.push(`Dialog ${i}: ${result.error}`);
+            // Keep original dialog on error
+          }
+        } else {
+          stats.errors.push(`Dialog ${i}: S3 config not provided for externalization`);
+          processedDialogs.push(dialog);
+        }
+        break;
+    }
+  }
+
+  return { dialogs: processedDialogs, stats };
+}


### PR DESCRIPTION
## Summary

- Add `--media` option to import script with three modes: `strip` (default), `keep`, or `externalize`
- Strip embedded base64 recordings by default to reduce database size
- Optionally externalize media to S3 with presigned URLs per IETF vcon-core-01 spec
- Add media handling statistics to import summary output

## New CLI Options

```bash
--media=MODE          # How to handle embedded media (default: strip)
                      # - keep: Preserve embedded base64 media (large DB size)
                      # - strip: Remove embedded media, keep metadata only
                      # - externalize: Upload media to S3, replace with presigned URLs

--media-bucket=NAME   # S3 bucket for externalized media (required if --media=externalize)
--media-prefix=PATH   # S3 prefix for media files (default: 'media/')
--presigned-expiry=N  # Presigned URL expiration in days (default: 7)
```

## Usage Examples

```bash
# Default: Strip embedded media (recommended for most cases)
npx tsx scripts/load-legacy-vcons.ts

# Externalize media to S3 with presigned URLs
npx tsx scripts/load-legacy-vcons.ts --media=externalize --media-bucket=my-media-bucket
```

## Test plan

- [x] All 354 existing tests pass
- [ ] Test strip mode with vCons containing embedded recordings
- [ ] Test externalize mode with S3 bucket
- [ ] Verify presigned URLs work for media access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds media handling modes to the legacy vCon loader (strip/keep/externalize to S3 with presigned URLs) and updates vCon types to core-01, with CLI flags and media stats reporting.
> 
> - **Scripts (`scripts/load-legacy-vcons.ts`)**
>   - Add media handling modes: `--media=strip|keep|externalize` with `--media-bucket`, `--media-prefix`, `--presigned-expiry`.
>   - Integrate media processing into migration; supports stripping or externalizing embedded base64 recordings to S3 with presigned URLs.
>   - Track and print media stats (`withEmbeddedMedia`, `stripped`, `externalized`, `externalizedBytes`).
>   - Enhance result typing and batch processing to accumulate media metrics.
> - **Types (`src/types/vcon.ts`)**
>   - Update to vcon-core-01: dialog content supports inline (`body`+`encoding`) or external (`url`+`content_hash`); add clarifying fields and constraints.
> - **Utils (`src/utils/media-storage.ts`)**
>   - New utility to detect embedded media, upload to S3, generate presigned URLs, compute hashes, and transform `Dialog` objects; exposes `processDialogsForMedia` and helpers.
> - **Dependencies**
>   - Add `@aws-sdk/s3-request-presigner` for presigned URL generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d5203f5b25f553c2c029839b209d938872be7a2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->