### PR TITLE
Updates scripts for created_at in attachments and analysis, migrations

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -337,10 +337,10 @@ export class VConQueries {
    * ✅ CRITICAL: 'body' is TEXT type
    */
   async addAnalysis(vconUuid: string, analysis: Analysis): Promise<void> {
-    // Get vcon_id
+    // Get vcon_id and created_at
     const { data: vcon, error: vconError } = await this.supabase
       .from('vcons')
-      .select('id')
+      .select('id, created_at')
       .eq('uuid', vconUuid)
       .single();
 
@@ -380,6 +380,7 @@ export class VConQueries {
         encoding: analysis.encoding,
         url: analysis.url,
         content_hash: analysis.content_hash,
+        created_at: vcon.created_at,
       });
 
     if (analysisError) throw analysisError;
@@ -468,7 +469,7 @@ export class VConQueries {
   async addAttachment(vconUuid: string, attachment: Attachment): Promise<void> {
     const { data: vcon, error: vconError } = await this.supabase
       .from('vcons')
-      .select('id')
+      .select('id, created_at')
       .eq('uuid', vconUuid)
       .single();
 
@@ -501,6 +502,7 @@ export class VConQueries {
         encoding: attachment.encoding,
         url: attachment.url,
         content_hash: attachment.content_hash,
+        created_at: vcon.created_at,
       });
 
     if (attachmentError) throw attachmentError;

--- a/supabase/migrations/20251212210000_fix_exec_sql_and_embeddings_384.sql
+++ b/supabase/migrations/20251212210000_fix_exec_sql_and_embeddings_384.sql
@@ -1,0 +1,187 @@
+-- Fix remote DB compatibility for:
+-- 1) exec_sql RPC parameter names expected by the TypeScript server (`q`, `params`)
+-- 2) embedding dimension and RPC signatures expected by the server (vector(384))
+--
+-- This migration is intended to be safe and idempotent.
+
+-- ============================================================================
+-- 1) exec_sql wrapper with parameter names: q, params
+-- ============================================================================
+-- The repo previously created exec_sql(query_params jsonb, query_text text).
+-- The TypeScript code calls: supabase.rpc('exec_sql', { q: '...', params: {} })
+-- Supabase requires RPC argument names to match Postgres function parameter names.
+
+CREATE OR REPLACE FUNCTION exec_sql(
+  q text,
+  params jsonb DEFAULT '{}'::jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  -- Delegate to the existing exec_sql(jsonb, text) overload if present.
+  RETURN exec_sql(params, q);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION exec_sql(text, jsonb) TO authenticated, service_role, anon;
+
+COMMENT ON FUNCTION exec_sql(text, jsonb) IS
+  'Compatibility wrapper: exec_sql(q text, params jsonb). Delegates to exec_sql(query_params jsonb, query_text text).';
+
+-- ============================================================================
+-- 2) Ensure embeddings are 384 dimensions and RPCs accept vector(384)
+-- ============================================================================
+
+-- Drop any existing RPCs that conflict in return shape or signature.
+-- Postgres does not allow changing a function's OUT parameter types via CREATE OR REPLACE.
+DROP FUNCTION IF EXISTS search_vcons_semantic CASCADE;
+DROP FUNCTION IF EXISTS search_vcons_hybrid CASCADE;
+
+-- If the table exists, enforce vector(384). If it does not exist, later migrations will create it.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'vcon_embeddings'
+  ) THEN
+    -- Ensure extension exists
+    CREATE EXTENSION IF NOT EXISTS vector;
+
+    -- Enforce embedding dimension
+    ALTER TABLE vcon_embeddings
+      ALTER COLUMN embedding TYPE vector(384);
+
+    -- Update defaults if columns exist
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'vcon_embeddings' AND column_name = 'embedding_dimension'
+    ) THEN
+      ALTER TABLE vcon_embeddings ALTER COLUMN embedding_dimension SET DEFAULT 384;
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'vcon_embeddings' AND column_name = 'embedding_model'
+    ) THEN
+      ALTER TABLE vcon_embeddings ALTER COLUMN embedding_model SET DEFAULT 'sentence-transformers/all-MiniLM-L6-v2';
+    END IF;
+
+    -- Recreate HNSW index for cosine similarity (safe if not present)
+    DROP INDEX IF EXISTS vcon_embeddings_hnsw_cosine;
+    CREATE INDEX vcon_embeddings_hnsw_cosine
+      ON vcon_embeddings USING hnsw (embedding vector_cosine_ops)
+      WITH (m = 16, ef_construction = 64);
+  END IF;
+END;
+$$;
+
+-- Semantic search: accept vector(384). Keep return columns compatible with server.
+CREATE OR REPLACE FUNCTION search_vcons_semantic(
+  query_embedding vector(384),
+  tag_filter jsonb DEFAULT '{}'::jsonb,
+  match_threshold float DEFAULT 0.7,
+  match_count int DEFAULT 50
+)
+RETURNS TABLE (
+  vcon_id uuid,
+  content_type text,
+  content_reference text,
+  content_text text,
+  similarity float
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT e.vcon_id, e.content_type, e.content_reference, e.content_text,
+         1 - (e.embedding <=> query_embedding) AS similarity
+  FROM vcon_embeddings e
+  LEFT JOIN vcon_tags_mv ta ON ta.vcon_id = e.vcon_id
+  WHERE 1 - (e.embedding <=> query_embedding) > match_threshold
+    AND (tag_filter = '{}'::jsonb OR (ta.tags IS NOT NULL AND ta.tags @> tag_filter))
+  ORDER BY e.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;
+
+-- Hybrid search: accept vector(384). Keyword-only operation still works with NULL embedding.
+CREATE OR REPLACE FUNCTION search_vcons_hybrid(
+  keyword_query text DEFAULT NULL,
+  query_embedding vector(384) DEFAULT NULL,
+  tag_filter jsonb DEFAULT '{}'::jsonb,
+  semantic_weight double precision DEFAULT 0.6,
+  limit_results int DEFAULT 50
+)
+RETURNS TABLE (
+  vcon_id uuid,
+  combined_score double precision,
+  semantic_score double precision,
+  keyword_score double precision
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH sem AS (
+    SELECT e.vcon_id, MAX((1 - (e.embedding <=> query_embedding))::double precision) AS semantic_score
+    FROM vcon_embeddings e
+    WHERE query_embedding IS NOT NULL
+    GROUP BY e.vcon_id
+  ),
+  kw AS (
+    SELECT vcon_id, MAX(keyword_score) AS keyword_score
+    FROM (
+      SELECT v.id AS vcon_id,
+             ts_rank_cd(v.subject_tsvector, plainto_tsquery('english', keyword_query), 32)::double precision AS keyword_score
+      FROM vcons v
+      WHERE keyword_query IS NOT NULL
+        AND v.subject_tsvector IS NOT NULL
+        AND v.subject_tsvector @@ plainto_tsquery('english', keyword_query)
+      UNION ALL
+      SELECT p.vcon_id,
+             ts_rank_cd(p.party_tsvector, plainto_tsquery('simple', keyword_query), 32)::double precision * 0.8 AS keyword_score
+      FROM parties p
+      WHERE keyword_query IS NOT NULL
+        AND p.party_tsvector IS NOT NULL
+        AND p.party_tsvector @@ plainto_tsquery('simple', keyword_query)
+      UNION ALL
+      SELECT d.vcon_id,
+             ts_rank_cd(d.body_tsvector, plainto_tsquery('english', keyword_query), 32)::double precision * 0.6 AS keyword_score
+      FROM dialog d
+      WHERE keyword_query IS NOT NULL
+        AND d.body_tsvector IS NOT NULL
+        AND d.body_tsvector @@ plainto_tsquery('english', keyword_query)
+      UNION ALL
+      SELECT a.vcon_id,
+             ts_rank_cd(a.body_tsvector, plainto_tsquery('english', keyword_query), 32)::double precision * 0.8 AS keyword_score
+      FROM analysis a
+      WHERE keyword_query IS NOT NULL
+        AND a.body_tsvector IS NOT NULL
+        AND a.body_tsvector @@ plainto_tsquery('english', keyword_query)
+    ) keyword_matches
+    WHERE keyword_query IS NOT NULL
+    GROUP BY vcon_id
+  )
+  SELECT v.id AS vcon_id,
+         (coalesce(s.semantic_score, 0) * semantic_weight
+         + coalesce(k.keyword_score, 0) * (1 - semantic_weight))::double precision AS combined_score,
+         coalesce(s.semantic_score, 0)::double precision AS semantic_score,
+         coalesce(k.keyword_score, 0)::double precision AS keyword_score
+  FROM vcons v
+  LEFT JOIN sem s ON s.vcon_id = v.id
+  LEFT JOIN kw  k ON k.vcon_id = v.id
+  LEFT JOIN vcon_tags_mv ta ON ta.vcon_id = v.id
+  WHERE (tag_filter = '{}'::jsonb OR (ta.tags IS NOT NULL AND ta.tags @> tag_filter))
+    AND ((query_embedding IS NOT NULL AND s.semantic_score IS NOT NULL)
+      OR (keyword_query   IS NOT NULL AND k.keyword_score IS NOT NULL))
+  ORDER BY combined_score DESC
+  LIMIT limit_results;
+END;
+$$;
+
+

--- a/supabase/migrations/20251212213000_fix_search_rpcs.sql
+++ b/supabase/migrations/20251212213000_fix_search_rpcs.sql
@@ -1,0 +1,204 @@
+-- Fix search RPC functions on remote:
+-- - search_vcons_keyword: eliminate return type mismatches by explicit casting and stable tenant filtering
+-- - search_vcons_hybrid: eliminate ambiguous column references and align to vector(384)
+
+-- Drop any existing versions (including older signatures/return shapes).
+DROP FUNCTION IF EXISTS search_vcons_keyword CASCADE;
+DROP FUNCTION IF EXISTS search_vcons_hybrid CASCADE;
+
+-- ============================================================================
+-- Keyword search (FTS) with tenant filtering and optional tags filter.
+-- Uses materialized tsvector columns if present.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION search_vcons_keyword(
+  query_text text,
+  start_date timestamptz DEFAULT NULL,
+  end_date   timestamptz DEFAULT NULL,
+  tag_filter jsonb DEFAULT '{}'::jsonb,
+  max_results int DEFAULT 50
+)
+RETURNS TABLE (
+  vcon_id uuid,
+  doc_type text,
+  ref_index int,
+  rank double precision,
+  snippet text
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+  current_tenant TEXT;
+BEGIN
+  current_tenant := get_current_tenant_id();
+
+  RETURN QUERY
+  WITH base AS (
+    -- Subject
+    SELECT v.id::uuid AS vcon_id,
+           'subject'::text AS doc_type,
+           NULL::int AS ref_index,
+           v.subject::text AS content,
+           v.subject_tsvector AS tsv
+    FROM vcons v
+    WHERE (start_date IS NULL OR v.created_at >= start_date)
+      AND (end_date   IS NULL OR v.created_at <= end_date)
+      AND (current_tenant IS NULL OR v.tenant_id IS NULL OR v.tenant_id = current_tenant)
+      AND v.subject_tsvector IS NOT NULL
+      AND v.subject_tsvector @@ plainto_tsquery('english', query_text)
+
+    UNION ALL
+
+    -- Parties
+    SELECT p.vcon_id::uuid AS vcon_id,
+           'party'::text AS doc_type,
+           p.party_index::int AS ref_index,
+           concat_ws(' ', p.name, p.mailto, p.tel)::text AS content,
+           p.party_tsvector AS tsv
+    FROM parties p
+    WHERE (current_tenant IS NULL OR p.tenant_id IS NULL OR p.tenant_id = current_tenant)
+      AND p.party_tsvector IS NOT NULL
+      AND p.party_tsvector @@ plainto_tsquery('simple', query_text)
+
+    UNION ALL
+
+    -- Dialog
+    SELECT d.vcon_id::uuid AS vcon_id,
+           'dialog'::text AS doc_type,
+           d.dialog_index::int AS ref_index,
+           d.body::text AS content,
+           d.body_tsvector AS tsv
+    FROM dialog d
+    WHERE (current_tenant IS NULL OR d.tenant_id IS NULL OR d.tenant_id = current_tenant)
+      AND d.body_tsvector IS NOT NULL
+      AND d.body_tsvector @@ plainto_tsquery('english', query_text)
+
+    UNION ALL
+
+    -- Analysis
+    SELECT a.vcon_id::uuid AS vcon_id,
+           'analysis'::text AS doc_type,
+           a.analysis_index::int AS ref_index,
+           a.body::text AS content,
+           a.body_tsvector AS tsv
+    FROM analysis a
+    WHERE (current_tenant IS NULL OR a.tenant_id IS NULL OR a.tenant_id = current_tenant)
+      AND a.body_tsvector IS NOT NULL
+      AND a.body_tsvector @@ plainto_tsquery('english', query_text)
+  )
+  SELECT b.vcon_id,
+         b.doc_type,
+         b.ref_index,
+         ts_rank_cd(b.tsv, plainto_tsquery('english', query_text), 32)::double precision AS rank,
+         ts_headline(
+           'english',
+           b.content,
+           plainto_tsquery('english', query_text),
+           'ShortWord=2, MinWords=5, MaxWords=20, HighlightAll=TRUE'
+         )::text AS snippet
+  FROM base b
+  LEFT JOIN vcon_tags_mv ta ON ta.vcon_id = b.vcon_id
+  WHERE (tag_filter = '{}'::jsonb OR (ta.tags IS NOT NULL AND ta.tags @> tag_filter))
+  ORDER BY rank DESC
+  LIMIT max_results;
+END;
+$$;
+
+-- ============================================================================
+-- Hybrid search: keyword + semantic, aligned to vector(384)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION search_vcons_hybrid(
+  keyword_query text DEFAULT NULL,
+  query_embedding vector(384) DEFAULT NULL,
+  tag_filter jsonb DEFAULT '{}'::jsonb,
+  semantic_weight double precision DEFAULT 0.6,
+  limit_results int DEFAULT 50
+)
+RETURNS TABLE (
+  vcon_id uuid,
+  combined_score double precision,
+  semantic_score double precision,
+  keyword_score double precision
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+  current_tenant TEXT;
+BEGIN
+  current_tenant := get_current_tenant_id();
+
+  RETURN QUERY
+  WITH sem AS (
+    SELECT e.vcon_id::uuid AS vcon_id,
+           MAX((1 - (e.embedding <=> query_embedding))::double precision) AS semantic_score
+    FROM vcon_embeddings e
+    WHERE query_embedding IS NOT NULL
+      AND (current_tenant IS NULL OR e.tenant_id IS NULL OR e.tenant_id = current_tenant)
+    GROUP BY e.vcon_id
+  ),
+  kw AS (
+    SELECT km.vcon_id::uuid AS vcon_id,
+           MAX(km.keyword_score)::double precision AS keyword_score
+    FROM (
+      SELECT v.id::uuid AS vcon_id,
+             ts_rank_cd(v.subject_tsvector, plainto_tsquery('english', keyword_query), 32)::double precision AS keyword_score
+      FROM vcons v
+      WHERE keyword_query IS NOT NULL
+        AND (current_tenant IS NULL OR v.tenant_id IS NULL OR v.tenant_id = current_tenant)
+        AND v.subject_tsvector IS NOT NULL
+        AND v.subject_tsvector @@ plainto_tsquery('english', keyword_query)
+
+      UNION ALL
+
+      SELECT p.vcon_id::uuid AS vcon_id,
+             ts_rank_cd(p.party_tsvector, plainto_tsquery('simple', keyword_query), 32)::double precision * 0.8 AS keyword_score
+      FROM parties p
+      WHERE keyword_query IS NOT NULL
+        AND (current_tenant IS NULL OR p.tenant_id IS NULL OR p.tenant_id = current_tenant)
+        AND p.party_tsvector IS NOT NULL
+        AND p.party_tsvector @@ plainto_tsquery('simple', keyword_query)
+
+      UNION ALL
+
+      SELECT d.vcon_id::uuid AS vcon_id,
+             ts_rank_cd(d.body_tsvector, plainto_tsquery('english', keyword_query), 32)::double precision * 0.6 AS keyword_score
+      FROM dialog d
+      WHERE keyword_query IS NOT NULL
+        AND (current_tenant IS NULL OR d.tenant_id IS NULL OR d.tenant_id = current_tenant)
+        AND d.body_tsvector IS NOT NULL
+        AND d.body_tsvector @@ plainto_tsquery('english', keyword_query)
+
+      UNION ALL
+
+      SELECT a.vcon_id::uuid AS vcon_id,
+             ts_rank_cd(a.body_tsvector, plainto_tsquery('english', keyword_query), 32)::double precision * 0.8 AS keyword_score
+      FROM analysis a
+      WHERE keyword_query IS NOT NULL
+        AND (current_tenant IS NULL OR a.tenant_id IS NULL OR a.tenant_id = current_tenant)
+        AND a.body_tsvector IS NOT NULL
+        AND a.body_tsvector @@ plainto_tsquery('english', keyword_query)
+    ) km
+    WHERE keyword_query IS NOT NULL
+    GROUP BY km.vcon_id
+  )
+  SELECT v.id::uuid AS vcon_id,
+         (coalesce(s.semantic_score, 0) * semantic_weight
+          + coalesce(k.keyword_score, 0) * (1 - semantic_weight))::double precision AS combined_score,
+         coalesce(s.semantic_score, 0)::double precision AS semantic_score,
+         coalesce(k.keyword_score, 0)::double precision AS keyword_score
+  FROM vcons v
+  LEFT JOIN sem s ON s.vcon_id = v.id
+  LEFT JOIN kw  k ON k.vcon_id = v.id
+  LEFT JOIN vcon_tags_mv ta ON ta.vcon_id = v.id
+  WHERE (tag_filter = '{}'::jsonb OR (ta.tags IS NOT NULL AND ta.tags @> tag_filter))
+    AND (
+      (query_embedding IS NOT NULL AND s.vcon_id IS NOT NULL)
+      OR (keyword_query IS NOT NULL AND k.vcon_id IS NOT NULL)
+    )
+  ORDER BY combined_score DESC
+  LIMIT limit_results;
+END;
+$$;
+
+

--- a/supabase/migrations/20251216120226_add_created_at_to_attachments.sql
+++ b/supabase/migrations/20251216120226_add_created_at_to_attachments.sql
@@ -1,0 +1,9 @@
+-- Migration: Add created_at tracking for attachments and analysis
+-- Backfill was run manually due to table size.
+
+-- Add created_at column to attachments table if it doesn't exist
+ALTER TABLE attachments ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ;
+
+-- Add indexes for efficient queries by created_at
+CREATE INDEX IF NOT EXISTS idx_attachments_created_at ON attachments(created_at);
+CREATE INDEX IF NOT EXISTS idx_analysis_created_at ON analysis(created_at);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Propagates vCon created_at into new analysis/attachment rows and adds DB migrations for exec_sql wrapper, vector(384) embeddings, and corrected keyword/semantic/hybrid search RPCs with indexes.
> 
> - **Database Migrations**:
>   - **RPC Compatibility**: Add `exec_sql(q text, params jsonb)` wrapper and grant execute.
>   - **Embeddings/Search**: Enforce `vector(384)` on `vcon_embeddings`, recreate HNSW index, and redefine `search_vcons_semantic` and `search_vcons_hybrid` to accept `vector(384)` and support tag filters.
>   - **Keyword Search RPC**: Recreate `search_vcons_keyword` with stable tenant filtering, explicit casts, snippets, and tag filtering; align `search_vcons_hybrid` accordingly.
>   - **Timestamps/Indexes**: Add `created_at` to `attachments`; add indexes on `attachments(created_at)` and `analysis(created_at)`.
> - **Server (queries.ts)**:
>   - **created_at Propagation**: When adding `analysis` and `attachments`, fetch `vcons.id, created_at` and insert `created_at` into new rows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b71e73573f935e6afa63bdc17bb74ba909771c3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->