### PR TITLE
feat(observability): Migrate to Pino structured logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,11 +26,14 @@
         "dotenv": "^16.4.0",
         "ioredis": "^5.4.1",
         "p-limit": "^7.2.0",
+        "pino": "^10.1.0",
+        "pino-pretty": "^13.1.3",
         "redis": "^5.9.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/node": "^24.7.0",
+        "@types/pino": "^7.0.4",
         "@typescript-eslint/eslint-plugin": "^8.46.0",
         "@typescript-eslint/parser": "^8.46.0",
         "@vitest/coverage-v8": "^3.2.4",
@@ -4590,6 +4593,12 @@
         "@opentelemetry/api": "^1.1.0"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -6079,6 +6088,16 @@
       "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
       "license": "MIT"
     },
+    "node_modules/@types/pino": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-7.0.4.tgz",
+      "integrity": "sha512-yKw1UbZOTe7vP1xMQT+oz3FexwgIpBTrM+AC62vWgAkNRULgLTJWfYX+H5/sKPm8VXFbIcXkC3VZPyuaNioZFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pino": "*"
+      }
+    },
     "node_modules/@types/shimmer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
@@ -6939,6 +6958,15 @@
         "js-tokens": "^9.0.1"
       }
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -7254,6 +7282,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -7360,6 +7394,15 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -7497,6 +7540,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -7947,6 +7999,12 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
+      "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7994,6 +8052,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
@@ -8410,6 +8474,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -8735,6 +8805,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -9122,6 +9201,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -9232,6 +9320,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -9501,6 +9598,88 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.1.0.tgz",
+      "integrity": "sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
@@ -9599,6 +9778,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -9647,6 +9842,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9692,6 +9897,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -9730,6 +9941,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redis": {
@@ -9979,6 +10199,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -9992,6 +10221,22 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -10184,6 +10429,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -10213,6 +10467,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -10459,6 +10722,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -85,11 +85,14 @@
     "dotenv": "^16.4.0",
     "ioredis": "^5.4.1",
     "p-limit": "^7.2.0",
+    "pino": "^10.1.0",
+    "pino-pretty": "^13.1.3",
     "redis": "^5.9.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^24.7.0",
+    "@types/pino": "^7.0.4",
     "@typescript-eslint/eslint-plugin": "^8.46.0",
     "@typescript-eslint/parser": "^8.46.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,6 +1,6 @@
 /**
  * Database Queries for vCon Operations
- * 
+ *
  * ⚠️ CRITICAL: Uses corrected field names per IETF spec
  * - analysis.schema (NOT schema_version)
  * - analysis.vendor (REQUIRED)
@@ -11,10 +11,13 @@
 
 import { SupabaseClient } from '@supabase/supabase-js';
 import Redis from 'ioredis';
-import { VCon, Analysis, Dialog, Party, Attachment } from '../types/vcon.js';
-import { withSpan, recordCounter, recordHistogram, logWithContext } from '../observability/instrumentation.js';
-import { ATTR_VCON_UUID, ATTR_DB_OPERATION, ATTR_CACHE_HIT, ATTR_SEARCH_TYPE, ATTR_SEARCH_RESULTS_COUNT, ATTR_SEARCH_THRESHOLD } from '../observability/attributes.js';
-import { getTenantConfig, extractTenantFromVCon } from '../config/tenant-config.js';
+import { extractTenantFromVCon, getTenantConfig } from '../config/tenant-config.js';
+import { ATTR_CACHE_HIT, ATTR_DB_OPERATION, ATTR_SEARCH_RESULTS_COUNT, ATTR_SEARCH_THRESHOLD, ATTR_SEARCH_TYPE, ATTR_VCON_UUID } from '../observability/attributes.js';
+import { logWithContext, recordCounter, withSpan } from '../observability/instrumentation.js';
+import { createLogger } from '../observability/logger.js';
+import { Analysis, Attachment, Dialog, VCon } from '../types/vcon.js';
+
+const logger = createLogger('queries');
 
 export class VConQueries {
   private redis: Redis | null = null;
@@ -51,11 +54,11 @@ export class VConQueries {
         [ATTR_VCON_UUID]: vcon.uuid,
         [ATTR_DB_OPERATION]: 'insert',
       });
-      
+
       recordCounter('db.query.count', 1, {
         operation: 'createVCon',
       }, 'Database query count');
-      
+
       // Extract tenant_id from vCon attachments if RLS is enabled
       const tenantConfig = getTenantConfig();
       let tenantId: string | null = null;
@@ -65,7 +68,7 @@ export class VConQueries {
           span.setAttributes({ 'tenant_id': tenantId });
         }
       }
-      
+
       // Insert main vcon
       const { data: vconData, error: vconError } = await this.supabase
         .from('vcons')
@@ -169,11 +172,11 @@ export class VConQueries {
         [ATTR_SEARCH_TYPE]: 'keyword',
         [ATTR_DB_OPERATION]: 'search',
       });
-      
+
       recordCounter('db.query.count', 1, {
         operation: 'keywordSearch',
       }, 'Database query count');
-      
+
       const { data, error } = await this.supabase.rpc('search_vcons_keyword', {
         query_text: params.query,
         start_date: params.startDate ?? null,
@@ -181,7 +184,7 @@ export class VConQueries {
         tag_filter: params.tags ?? {},
         max_results: params.limit ?? 50,
       });
-      
+
       if (error) {
         recordCounter('db.query.errors', 1, {
           operation: 'keywordSearch',
@@ -189,23 +192,23 @@ export class VConQueries {
         }, 'Database query errors');
         throw error;
       }
-      
+
       const results = data as any;
       span.setAttributes({
         [ATTR_SEARCH_RESULTS_COUNT]: results?.length || 0,
       });
-      
+
       return results;
     });
   }
 
   /**
    * Get count of distinct vCons matching keyword search criteria
-   * 
+   *
    * NOTE: This method has a limitation - it fetches results and counts distinct vcon_ids,
    * which means it's still subject to Supabase's 1000 row limit. For accurate counts
    * exceeding 1000, a database RPC function that returns count directly would be needed.
-   * 
+   *
    * @param params - Search parameters
    * @returns Count of distinct vCons matching the search
    */
@@ -221,7 +224,7 @@ export class VConQueries {
       ...params,
       limit: 1000, // Maximum allowed by Supabase
     });
-    
+
     // Count distinct vcon_ids (since one vcon can match multiple times)
     const distinctVconIds = new Set(results.map(r => r.vcon_id));
     return distinctVconIds.size;
@@ -249,18 +252,18 @@ export class VConQueries {
         [ATTR_DB_OPERATION]: 'search',
         [ATTR_SEARCH_THRESHOLD]: params.threshold || 0.7,
       });
-      
+
       recordCounter('db.query.count', 1, {
         operation: 'semanticSearch',
       }, 'Database query count');
-      
+
       const { data, error } = await this.supabase.rpc('search_vcons_semantic', {
         query_embedding: params.embedding,
         tag_filter: params.tags ?? {},
         match_threshold: params.threshold ?? 0.7,
         match_count: params.limit ?? 50,
       });
-      
+
       if (error) {
         recordCounter('db.query.errors', 1, {
           operation: 'semanticSearch',
@@ -268,12 +271,12 @@ export class VConQueries {
         }, 'Database query errors');
         throw error;
       }
-      
+
       const results = data as any;
       span.setAttributes({
         [ATTR_SEARCH_RESULTS_COUNT]: results?.length || 0,
       });
-      
+
       return results;
     });
   }
@@ -300,11 +303,11 @@ export class VConQueries {
         [ATTR_DB_OPERATION]: 'search',
         'search.semantic_weight': params.semanticWeight || 0.6,
       });
-      
+
       recordCounter('db.query.count', 1, {
         operation: 'hybridSearch',
       }, 'Database query count');
-      
+
       const { data, error } = await this.supabase.rpc('search_vcons_hybrid', {
         keyword_query: params.keywordQuery ?? null,
         query_embedding: params.embedding ?? null,
@@ -312,7 +315,7 @@ export class VConQueries {
         semantic_weight: params.semanticWeight ?? 0.6,
         limit_results: params.limit ?? 50,
       });
-      
+
       if (error) {
         recordCounter('db.query.errors', 1, {
           operation: 'hybridSearch',
@@ -320,12 +323,12 @@ export class VConQueries {
         }, 'Database query errors');
         throw error;
       }
-      
+
       const results = data as any;
       span.setAttributes({
         [ATTR_SEARCH_RESULTS_COUNT]: results?.length || 0,
       });
-      
+
       return results;
     });
   }
@@ -354,8 +357,8 @@ export class VConQueries {
       .order('analysis_index', { ascending: false })
       .limit(1);
 
-    const nextIndex = existingAnalysis && existingAnalysis.length > 0 
-      ? existingAnalysis[0].analysis_index + 1 
+    const nextIndex = existingAnalysis && existingAnalysis.length > 0
+      ? existingAnalysis[0].analysis_index + 1
       : 0;
 
     // ✅ CRITICAL CORRECTIONS:
@@ -368,8 +371,8 @@ export class VConQueries {
         vcon_id: vcon.id,
         analysis_index: nextIndex,
         type: analysis.type,
-        dialog_indices: Array.isArray(analysis.dialog) 
-          ? analysis.dialog 
+        dialog_indices: Array.isArray(analysis.dialog)
+          ? analysis.dialog
           : (analysis.dialog !== undefined ? [analysis.dialog] : null),
         mediatype: analysis.mediatype,
         filename: analysis.filename,
@@ -407,8 +410,8 @@ export class VConQueries {
       .order('dialog_index', { ascending: false })
       .limit(1);
 
-    const nextIndex = existingDialog && existingDialog.length > 0 
-      ? existingDialog[0].dialog_index + 1 
+    const nextIndex = existingDialog && existingDialog.length > 0
+      ? existingDialog[0].dialog_index + 1
       : 0;
 
     // Normalize parties array
@@ -483,8 +486,8 @@ export class VConQueries {
       .order('attachment_index', { ascending: false })
       .limit(1);
 
-    const nextIndex = existingAttachments && existingAttachments.length > 0 
-      ? existingAttachments[0].attachment_index + 1 
+    const nextIndex = existingAttachments && existingAttachments.length > 0
+      ? existingAttachments[0].attachment_index + 1
       : 0;
 
     const { error: attachmentError } = await this.supabase
@@ -518,13 +521,17 @@ export class VConQueries {
     try {
       const cached = await this.redis.get(`vcon:${uuid}`);
       if (cached) {
-        console.error(`✅ Cache HIT for vCon ${uuid}`);
+        logger.debug({ vcon_uuid: uuid, cache_hit: true }, 'Cache hit');
         return JSON.parse(cached) as VCon;
       }
-      console.error(`ℹ️  Cache MISS for vCon ${uuid}`);
+      logger.debug({ vcon_uuid: uuid, cache_hit: false }, 'Cache miss');
       return null;
     } catch (error) {
-      console.error(`⚠️  Cache read error for ${uuid}:`, error);
+      logger.warn({
+        vcon_uuid: uuid,
+        err: error,
+        error_message: error instanceof Error ? error.message : String(error)
+      }, 'Cache read error');
       return null; // Fall through to database
     }
   }
@@ -542,9 +549,16 @@ export class VConQueries {
         this.cacheTTL,
         JSON.stringify(vcon)
       );
-      console.error(`✅ Cached vCon ${uuid} (TTL: ${this.cacheTTL}s)`);
+      logger.debug({
+        vcon_uuid: uuid,
+        ttl_seconds: this.cacheTTL
+      }, 'Cached vCon');
     } catch (error) {
-      console.error(`⚠️  Cache write error for ${uuid}:`, error);
+      logger.warn({
+        vcon_uuid: uuid,
+        err: error,
+        error_message: error instanceof Error ? error.message : String(error)
+      }, 'Cache write error');
       // Non-fatal: continue without caching
     }
   }
@@ -558,9 +572,13 @@ export class VConQueries {
 
     try {
       await this.redis.del(`vcon:${uuid}`);
-      console.error(`✅ Invalidated cache for vCon ${uuid}`);
+      logger.debug({ vcon_uuid: uuid }, 'Invalidated cache');
     } catch (error) {
-      console.error(`⚠️  Cache invalidation error for ${uuid}:`, error);
+      logger.warn({
+        vcon_uuid: uuid,
+        err: error,
+        error_message: error instanceof Error ? error.message : String(error)
+      }, 'Cache invalidation error');
     }
   }
 
@@ -575,7 +593,7 @@ export class VConQueries {
         [ATTR_VCON_UUID]: uuid,
         [ATTR_DB_OPERATION]: 'select',
       });
-      
+
       // Try cache first
       const cached = await this.getCachedVCon(uuid);
       if (cached) {
@@ -587,7 +605,7 @@ export class VConQueries {
       // Cache miss
       recordCounter('cache.miss', 1, { operation: 'getVCon' }, 'Cache misses');
       span.setAttributes({ [ATTR_CACHE_HIT]: false });
-      
+
       recordCounter('db.query.count', 1, {
         operation: 'getVCon',
       }, 'Database query count');
@@ -755,7 +773,7 @@ export class VConQueries {
       }
       throw fetchError;
     }
-    
+
     if (error) throw error;
     if (!data) {
       // This shouldn't happen if error is null, but TypeScript needs this check
@@ -784,14 +802,14 @@ export class VConQueries {
       if (partyError) throw partyError;
 
       const partyVconIds = new Set(partyData.map(p => p.vcon_id));
-      
+
       // Get UUIDs for matching vcon_ids
       const { data: matchingVcons } = await this.supabase
         .from('vcons')
         .select('uuid, id')
         .in('id', Array.from(partyVconIds));
 
-      vconUuids = vconUuids.filter(uuid => 
+      vconUuids = vconUuids.filter(uuid =>
         matchingVcons?.some(v => v.uuid === uuid)
       );
     }
@@ -866,7 +884,7 @@ export class VConQueries {
       }
 
       const partyVconIds = new Set(partyData.map(p => p.vcon_id));
-      
+
       // Apply date/subject filters and count only matching vcons
       let vconQuery = this.supabase
         .from('vcons')
@@ -885,22 +903,22 @@ export class VConQueries {
 
       const { count, error: countError } = await vconQuery;
       if (countError) throw countError;
-      
+
       // If tag filters, intersect with tag matching UUIDs
       if (filters.tags && Object.keys(filters.tags).length > 0) {
         const tagMatchingUuids = await this.searchByTags(filters.tags, 10000);
         const tagMatchingSet = new Set(tagMatchingUuids);
-        
+
         // Get UUIDs for the party-filtered vcons and count intersection
         const { data: vconData } = await this.supabase
           .from('vcons')
           .select('uuid')
           .in('id', Array.from(partyVconIds));
-        
+
         const matchingUuids = vconData?.filter(v => tagMatchingSet.has(v.uuid)).map(v => v.uuid) || [];
         return matchingUuids.length;
       }
-      
+
       return count || 0;
     }
 
@@ -908,11 +926,11 @@ export class VConQueries {
     if (filters.tags && Object.keys(filters.tags).length > 0) {
       const tagMatchingUuids = await this.searchByTags(filters.tags, 10000);
       const tagMatchingSet = new Set(tagMatchingUuids);
-      
+
       // Get all UUIDs from the base query (with subject/date filters)
       const { data: vconData } = await query.select('uuid');
       if (!vconData) return 0;
-      
+
       const matchingUuids = vconData.filter(v => tagMatchingSet.has(v.uuid));
       return matchingUuids.length;
     }
@@ -994,7 +1012,7 @@ export class VConQueries {
     // Parse tags from body (array of "key:value" strings)
     const tagsArray = JSON.parse(attachments[0].body || '[]');
     const tagsObject: Record<string, string> = {};
-    
+
     for (const tagString of tagsArray) {
       const colonIndex = tagString.indexOf(':');
       if (colonIndex > 0) {
@@ -1042,7 +1060,7 @@ export class VConQueries {
    */
   async removeTag(vconUuid: string, key: string): Promise<void> {
     const currentTags = await this.getTags(vconUuid);
-    
+
     if (currentTags[key] === undefined) {
       return; // Tag doesn't exist, nothing to do
     }
@@ -1061,7 +1079,7 @@ export class VConQueries {
       // Merge with existing tags
       const currentTags = await this.getTags(vconUuid);
       finalTags = { ...currentTags };
-      
+
       // Add/update new tags
       for (const [key, value] of Object.entries(tags)) {
         finalTags[key] = String(value);
@@ -1093,25 +1111,25 @@ export class VConQueries {
       tag_filter: tags,
       max_results: limit,
     });
-    
+
     // Add a 10 second timeout to prevent indefinite hangs
     const timeoutPromise = new Promise<{ data: null; error: Error }>((resolve) => {
       setTimeout(() => {
         resolve({ data: null, error: new Error('RPC call timed out') });
       }, 10000);
     });
-    
+
     const { data, error } = await Promise.race([rpcPromise, timeoutPromise]);
 
     // Helper function for manual search fallback
     const performManualSearch = async (): Promise<string[]> => {
       // Get all vCons with tags attachments (use pagination to bypass Supabase's 1000 row default limit)
       // Note: We look for type='tags' regardless of encoding to handle legacy data
-      
+
       // Add overall timeout to prevent indefinite execution
       const searchTimeout = 45000; // 45 seconds max for manual search
       const startTime = Date.now();
-      
+
       // First, get the total count
       const { count, error: countError } = await this.supabase
         .from('attachments')
@@ -1119,7 +1137,7 @@ export class VConQueries {
         .eq('type', 'tags');
 
       if (countError) throw countError;
-      
+
       // Check timeout before proceeding
       if (Date.now() - startTime > searchTimeout) {
         return [];
@@ -1138,7 +1156,7 @@ export class VConQueries {
         if (Date.now() - startTime > searchTimeout) {
           break;
         }
-        
+
         // Stop fetching if we have enough matches
         if (matchingVconIds.size >= limit) {
           break;
@@ -1146,7 +1164,7 @@ export class VConQueries {
 
         const from = i * batchSize;
         const to = Math.min(from + batchSize - 1, (count || 0) - 1);
-        
+
         const { data: batch, error: attachmentError } = await this.supabase
           .from('attachments')
           .select('vcon_id, body')
@@ -1160,7 +1178,7 @@ export class VConQueries {
           try {
             const tagsArray = JSON.parse(attachment.body || '[]');
             const tagsObject: Record<string, string> = {};
-            
+
             for (const tagString of tagsArray) {
               if (typeof tagString !== 'string') continue;
               const colonIndex = tagString.indexOf(':');
@@ -1255,7 +1273,7 @@ export class VConQueries {
     // Get all tags attachments (use pagination to bypass Supabase's 1000 row default limit)
     // Note: We look for type='tags' regardless of encoding to handle legacy data
     // Tags should have encoding='json', but we're lenient to find tags that may have wrong encoding
-    
+
     // First, get the total count
     const { count, error: countError } = await this.supabase
       .from('attachments')
@@ -1272,7 +1290,7 @@ export class VConQueries {
     for (let i = 0; i < totalBatches; i++) {
       const from = i * batchSize;
       const to = Math.min(from + batchSize - 1, (count || 0) - 1);
-      
+
       const { data: batch, error } = await this.supabase
         .from('attachments')
         .select('vcon_id, body, encoding')
@@ -1291,7 +1309,7 @@ export class VConQueries {
     let tagsWithWrongEncoding = 0;
     for (const attachment of attachments || []) {
       vconIds.add(attachment.vcon_id);
-      
+
       // Warn if encoding is not 'json' (tags should have encoding='json')
       if (attachment.encoding !== 'json') {
         tagsWithWrongEncoding++;
@@ -1303,10 +1321,10 @@ export class VConQueries {
           });
         }
       }
-      
+
       try {
         const tagsArray = JSON.parse(attachment.body || '[]');
-        
+
         if (!Array.isArray(tagsArray)) {
           logWithContext('warn', 'Tags attachment body is not an array', {
             vcon_id: attachment.vcon_id,
@@ -1314,12 +1332,12 @@ export class VConQueries {
           });
           continue;
         }
-        
+
         for (const tagString of tagsArray) {
           if (typeof tagString !== 'string') {
             continue;
           }
-          
+
           const colonIndex = tagString.indexOf(':');
           if (colonIndex > 0) {
             const key = tagString.substring(0, colonIndex);
@@ -1353,7 +1371,7 @@ export class VConQueries {
         // Continue processing other attachments
       }
     }
-    
+
     if (tagsWithWrongEncoding > 0) {
       logWithContext('info', `Processed ${tagsWithWrongEncoding} tags attachments with incorrect encoding`, {
         total_tags: attachments?.length || 0,
@@ -1367,7 +1385,7 @@ export class VConQueries {
 
     for (const [key, valuesSet] of Object.entries(allTags)) {
       const values: string[] = [];
-      
+
       for (const value of valuesSet) {
         const count = tagCounts[key]?.[value] ?? 1;
         if (count >= minCount) {
@@ -1440,8 +1458,8 @@ export class VConQueries {
         .order('attachment_index', { ascending: false })
         .limit(1);
 
-      const nextIndex = nextIndexData && nextIndexData.length > 0 
-        ? nextIndexData[0].attachment_index + 1 
+      const nextIndex = nextIndexData && nextIndexData.length > 0
+        ? nextIndexData[0].attachment_index + 1
         : 0;
 
       const { error: insertError } = await this.supabase
@@ -1464,4 +1482,3 @@ export class VConQueries {
       .eq('uuid', vconUuid);
   }
 }
-

--- a/src/observability/logger.ts
+++ b/src/observability/logger.ts
@@ -1,0 +1,134 @@
+/**
+ * Pino Logger Configuration with OpenTelemetry Integration
+ *
+ * Provides structured logging with automatic trace context injection
+ * and MCP-compliant stderr output.
+ */
+
+import { context, trace } from '@opentelemetry/api';
+import pino from 'pino';
+
+/**
+ * Mixin to automatically inject OpenTelemetry trace context into logs
+ */
+const traceContextMixin = (): Record<string, any> => {
+  const span = trace.getSpan(context.active());
+  const spanContext = span?.spanContext();
+
+  if (spanContext) {
+    return {
+      trace_id: spanContext.traceId,
+      span_id: spanContext.spanId,
+      trace_flags: spanContext.traceFlags,
+    };
+  }
+  return {};
+};
+
+/**
+ * Create root Pino logger instance
+ */
+function createRootLogger() {
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  const logLevel = process.env.LOG_LEVEL || (isDevelopment ? 'debug' : 'info');
+
+  const baseConfig: pino.LoggerOptions = {
+    level: logLevel,
+
+    // Inject OpenTelemetry trace context
+    mixin: traceContextMixin,
+
+    // Base fields for all logs
+    base: {
+      service: 'vcon-mcp-server',
+      version: process.env.npm_package_version || '1.0.0',
+    },
+
+    // Timestamp in ISO format
+    timestamp: pino.stdTimeFunctions.isoTime,
+  };
+
+  // Development: Pretty printing
+  if (isDevelopment) {
+    return pino(
+      {
+        ...baseConfig,
+        transport: {
+          target: 'pino-pretty',
+          options: {
+            colorize: true,
+            translateTime: 'HH:MM:ss.l',
+            ignore: 'pid,hostname',
+            messageFormat: '{component} - {msg}',
+            singleLine: false,
+          },
+        },
+      },
+      pino.destination(2) // stderr for MCP
+    );
+  }
+
+  // Production: JSON to stderr
+  return pino(baseConfig, pino.destination(2));
+}
+
+/**
+ * Root logger instance
+ */
+export const logger = createRootLogger();
+
+/**
+ * Create a child logger with component context
+ *
+ * @param component - Component name (e.g., 'queries', 'cache', 'plugins')
+ * @returns Child logger with component context
+ *
+ * @example
+ * const logger = createLogger('queries');
+ * logger.info({ vcon_uuid: 'abc' }, 'Cache hit');
+ */
+export function createLogger(component: string): pino.Logger {
+  return logger.child({ component });
+}
+
+/**
+ * Backward compatibility: Wrapper for existing logWithContext calls
+ *
+ * @deprecated Use logger.info/warn/error directly instead
+ */
+export function logWithContext(
+  level: 'debug' | 'info' | 'warn' | 'error',
+  message: string,
+  attributes?: Record<string, any>
+): void {
+  const logMethod = logger[level].bind(logger);
+  logMethod(attributes || {}, message);
+}
+
+/**
+ * Log levels for reference
+ */
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+/**
+ * Helper to log errors with full stack traces
+ *
+ * @param logger - Logger instance
+ * @param error - Error object
+ * @param message - Log message
+ * @param context - Additional context
+ */
+export function logError(
+  logger: pino.Logger,
+  error: unknown,
+  message: string,
+  context?: Record<string, any>
+): void {
+  logger.error(
+    {
+      err: error,
+      ...context,
+    },
+    message
+  );
+}


### PR DESCRIPTION
- Replace console.error with Pino logger for structured JSON logs
- Add OpenTelemetry trace context integration
- Support pretty printing in development (pino-pretty)
- Improve production observability with parseable log format

Benefits:
- Structured JSON logs searchable by any log aggregator
- Automatic trace_id/span_id injection from OpenTelemetry
- Proper log levels (trace, debug, info, warn, error, fatal)
- Better performance than console.* methods
- No breaking changes to existing functionality


NOTE : "Includes linter auto-fixes"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adopts Pino for structured logging (with pretty-print in dev) and injects OpenTelemetry trace context, replacing console logs across server, DB, and setup; adds required dependencies.
> 
> - **Observability/Logging**:
>   - **New logger**: Introduces `src/observability/logger.ts` using Pino with OTEL trace context injection; pretty-print in development; JSON to stderr in production.
>   - **OTEL config**: Updates `src/observability/config.ts` to use the new logger for init/shutdown diagnostics and clarifies console/OTLP exporters.
> - **Server & Runtime**:
>   - Replaces console logging with structured logs in `src/index.ts` and `src/server/setup.ts` (startup, plugin loading, shutdown paths).
>   - Enhances `src/db/queries.ts` cache/log statements using the new logger.
>   - Minor handler logging tweaks in `src/tools/handlers/search.ts`.
> - **Dependencies**:
>   - Adds `pino`, `pino-pretty`, and `@types/pino` in `package.json` (and lockfile).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63f25e3f3fefe9cbf2da230ffeb134045a8c58ca. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->