### PR TITLE
Update documentation links and references to use the new vcon-dev GitHub organization. This includes changes to URLs in the PUBLISHING_GUIDE.md, README.md, and various documentation files to reflect the updated repository location.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ temp/
 temp_loaded_uuids.json
 backups/
 
+# VitePress
+docs/.vitepress/cache/
+docs/.vitepress/dist/
+

--- a/PUBLISHING_GUIDE.md
+++ b/PUBLISHING_GUIDE.md
@@ -114,7 +114,7 @@ The main README.md serves as the npm package documentation.
   "homepage": "https://yourusername.github.io/vcon-mcp",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yourusername/vcon-mcp"
+    "url": "https://github.com/vcon-dev/vcon-mcp"
   },
   "keywords": [
     "vcon", "mcp", "ietf", "conversation", "supabase"
@@ -274,7 +274,7 @@ Add badges for quick info:
 ```markdown
 ![Version](https://img.shields.io/npm/v/@vcon/mcp-server)
 ![License](https://img.shields.io/badge/license-MIT-blue)
-![GitHub Stars](https://img.shields.io/github/stars/yourusername/vcon-mcp)
+![GitHub Stars](https://img.shields.io/github/stars/vcon-dev/vcon-mcp)
 ![Downloads](https://img.shields.io/npm/dm/@vcon/mcp-server)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1017,9 +1017,9 @@ MIT License - see [LICENSE](LICENSE) file for details
 
 ### Project Links
 
-- **GitHub**: [vcon-mcp](https://github.com/yourusername/vcon-mcp)
-- **Issues**: [Bug reports &amp; feature requests](https://github.com/yourusername/vcon-mcp/issues)
-- **Discussions**: [Community discussions](https://github.com/yourusername/vcon-mcp/discussions)
+- **GitHub**: [vcon-mcp](https://github.com/vcon-dev/vcon-mcp)
+- **Issues**: [Bug reports &amp; feature requests](https://github.com/vcon-dev/vcon-mcp/issues)
+- **Discussions**: [Community discussions](https://github.com/vcon-dev/vcon-mcp/discussions)
 
 ### External Links
 
@@ -1033,7 +1033,7 @@ MIT License - see [LICENSE](LICENSE) file for details
 - 📧 **Email**: ohjesus@doesanyoneemail.anymore
 - 💬 **Discord**: [Join our community](https://discord.gg/example)
 - 📖 **Documentation**: [Full docs](https://docs.example.com)
-- 🐛 **Bug Reports**: [GitHub Issues](https://github.com/yourusername/vcon-mcp/issues)
+- 🐛 **Bug Reports**: [GitHub Issues](https://github.com/vcon-dev/vcon-mcp/issues)
 
 ## Acknowledgments
 

--- a/archive/docs/REDIS_INTEGRATION.md
+++ b/archive/docs/REDIS_INTEGRATION.md
@@ -364,7 +364,7 @@ Complete documentation available:
 
 For issues or questions:
 
-- GitHub Issues: [vcon-mcp/issues](https://github.com/yourusername/vcon-mcp/issues)
+- GitHub Issues: [vcon-mcp/issues](https://github.com/vcon-dev/vcon-mcp/issues)
 - Documentation: [Full docs](docs/)
 - Email: support@example.com
 

--- a/archive/docs/REDIS_QUICKSTART.md
+++ b/archive/docs/REDIS_QUICKSTART.md
@@ -242,8 +242,8 @@ docker-compose restart
 ## Support
 
 - 📖 [Full Documentation](docs/guide/redis-supabase-integration.md)
-- 🐛 [Report Issues](https://github.com/yourusername/vcon-mcp/issues)
-- 💬 [Discussions](https://github.com/yourusername/vcon-mcp/discussions)
+- 🐛 [Report Issues](https://github.com/vcon-dev/vcon-mcp/issues)
+- 💬 [Discussions](https://github.com/vcon-dev/vcon-mcp/discussions)
 
 ## Summary
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -173,7 +173,7 @@ export default defineConfig({
     },
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/yourusername/vcon-mcp' },
+      { icon: 'github', link: 'https://github.com/vcon-dev/vcon-mcp' },
       { icon: 'npm', link: 'https://www.npmjs.com/package/@vcon/mcp-server' }
     ],
 
@@ -190,7 +190,7 @@ export default defineConfig({
     },
 
     editLink: {
-      pattern: 'https://github.com/yourusername/vcon-mcp/edit/main/docs/:path',
+      pattern: 'https://github.com/vcon-dev/vcon-mcp/edit/main/docs/:path',
       text: 'Edit this page on GitHub'
     },
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -430,7 +430,7 @@ redis-cli ping
 
 Need help with configuration?
 
-- GitHub Issues: [vcon-mcp/issues](https://github.com/yourusername/vcon-mcp/issues)
+- GitHub Issues: [vcon-mcp/issues](https://github.com/vcon-dev/vcon-mcp/issues)
 - Documentation: [Full docs](../)
 - Email: support@example.com
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -157,8 +157,8 @@ Ready to get started? Follow our guides:
 ## Getting Help
 
 - 📖 Check the [Troubleshooting Guide](./troubleshooting.md)
-- 💬 Ask in [GitHub Discussions](https://github.com/yourusername/vcon-mcp/discussions)
-- 🐛 Report bugs in [GitHub Issues](https://github.com/yourusername/vcon-mcp/issues)
+- 💬 Ask in [GitHub Discussions](https://github.com/vcon-dev/vcon-mcp/discussions)
+- 🐛 Report bugs in [GitHub Issues](https://github.com/vcon-dev/vcon-mcp/issues)
 - 📧 Contact the team at support@example.com
 
 ## Contributing
@@ -172,5 +172,5 @@ We welcome contributions! See our [Contributing Guide](../development/contributi
 
 ## License
 
-This project is released under the MIT License. See the [LICENSE](https://github.com/yourusername/vcon-mcp/blob/main/LICENSE) file for details.
+This project is released under the MIT License. See the [LICENSE](https://github.com/vcon-dev/vcon-mcp/blob/main/LICENSE) file for details.
 

--- a/docs/guide/redis-supabase-integration.md
+++ b/docs/guide/redis-supabase-integration.md
@@ -472,7 +472,7 @@ Typical performance with Redis caching enabled:
 
 For issues or questions:
 
-- GitHub Issues: [vcon-mcp/issues](https://github.com/yourusername/vcon-mcp/issues)
+- GitHub Issues: [vcon-mcp/issues](https://github.com/vcon-dev/vcon-mcp/issues)
 - Email: support@example.com
 - Documentation: [Full docs](https://docs.example.com)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ hero:
       link: /guide/getting-started
     - theme: alt
       text: View on GitHub
-      link: https://github.com/yourusername/vcon-mcp
+      link: https://github.com/vcon-dev/vcon-mcp
     - theme: alt
       text: API Reference
       link: /api/

--- a/examples/README.md
+++ b/examples/README.md
@@ -201,7 +201,7 @@ Have a useful example or integration? Submit a pull request!
 
 For questions about examples:
 
-- GitHub Issues: [vcon-mcp/issues](https://github.com/yourusername/vcon-mcp/issues)
+- GitHub Issues: [vcon-mcp/issues](https://github.com/vcon-dev/vcon-mcp/issues)
 - Documentation: [Full docs](../docs/)
 - Email: support@example.com
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Docs/link updates**
> 
> - Replaces GitHub repository, issues, and discussions URLs with `https://github.com/vcon-dev/vcon-mcp` across `README.md`, `PUBLISHING_GUIDE.md`, guides, archived Redis docs, and `examples/README.md`
> - Updates badges (GitHub Stars), README support links, and license link targets to `vcon-dev`
> - Adjusts VitePress `docs/.vitepress/config.ts` social links and `editLink.pattern` to the new org
> - Updates docs homepage `docs/index.md` "View on GitHub" link to the new repository
> 
> *No functional code changes; documentation and site configuration links only*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c6f2ad5d0511adcc44e5c7b126cb7a300c780a9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->