### PR TITLE
Implement Koa-based REST API for vCon operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@aws-sdk/client-s3": "^3.922.0",
         "@aws-sdk/credential-providers": "^3.927.0",
         "@aws-sdk/s3-request-presigner": "^3.922.0",
+        "@koa/cors": "^5.0.0",
+        "@koa/router": "^13.1.0",
         "@modelcontextprotocol/sdk": "^1.19.1",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.48.0",
@@ -25,6 +27,8 @@
         "@supabase/supabase-js": "^2.74.0",
         "dotenv": "^16.4.0",
         "ioredis": "^5.4.1",
+        "koa": "^3.1.1",
+        "koa-bodyparser": "^4.4.1",
         "p-limit": "^7.2.0",
         "pino": "^10.1.0",
         "pino-pretty": "^13.1.3",
@@ -32,6 +36,10 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@types/koa": "^2.15.0",
+        "@types/koa__cors": "^5.0.0",
+        "@types/koa__router": "^12.0.4",
+        "@types/koa-bodyparser": "^4.3.12",
         "@types/node": "^24.7.0",
         "@types/pino": "^7.0.4",
         "@typescript-eslint/eslint-plugin": "^8.46.0",
@@ -2864,6 +2872,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hapi/bourne": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3015,6 +3029,40 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@koa/cors": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
+      "integrity": "sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==",
+      "license": "MIT",
+      "dependencies": {
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@koa/router": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-13.1.1.tgz",
+      "integrity": "sha512-JQEuMANYRVHs7lm7KY9PCIjkgJk73h4m4J+g2mkw2Vo1ugPZ17UJVqEH8F+HeAdjKz5do1OaLe7ArDz+z308gw==",
+      "deprecated": "Please upgrade to v15 or higher. All reported bugs in this version are fixed in newer releases, dependencies have been updated, and security has been improved.",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^6.3.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@koa/router/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.20.0",
@@ -5935,11 +5983,32 @@
         "@supabase/storage-js": "2.75.0"
       }
     },
+    "node_modules/@types/accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.122",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.122.tgz",
       "integrity": "sha512-vBkIh9AY22kVOCEKo5CJlyCgmSWvasC+SWUxL/x/vOwRobMpI/HG1xp/Ae3AqmSiZeLUbOhW0FCD3ZjqqUxmXw==",
       "license": "MIT"
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/bunyan": {
       "version": "1.8.9",
@@ -5969,6 +6038,26 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/content-disposition": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.9.tgz",
+      "integrity": "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/cookies": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.2.tgz",
+      "integrity": "sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5983,6 +6072,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
+      "integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -5993,12 +6107,90 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/http-assert": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.6.tgz",
+      "integrity": "sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/keygrip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
+      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/koa": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
+      "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/accepts": "*",
+        "@types/content-disposition": "*",
+        "@types/cookies": "*",
+        "@types/http-assert": "*",
+        "@types/http-errors": "*",
+        "@types/keygrip": "*",
+        "@types/koa-compose": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/koa__cors": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-5.0.1.tgz",
+      "integrity": "sha512-xZckuh3B6ycSBAIYnBImG1VDHyBNZsltGAuGb4THuZllccdLgD5DUs4RA7TAUjB58THg00SSZ1e//duQef7WRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/koa": "*"
+      }
+    },
+    "node_modules/@types/koa__router": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-12.0.5.tgz",
+      "integrity": "sha512-1HeLxuDn4n5it1yZYCSyOYXo++73zT0ffoviXnPxbwbxLbvDFEvWD9ZzpRiIpK4oKR0pi+K+Mk/ZjyROjW3HSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/koa": "*"
+      }
+    },
+    "node_modules/@types/koa-bodyparser": {
+      "version": "4.3.13",
+      "resolved": "https://registry.npmjs.org/@types/koa-bodyparser/-/koa-bodyparser-4.3.13.tgz",
+      "integrity": "sha512-yW9afsDnV1ymnhMBfAlzsKZ45sYnvIlTRS+eF5MUZOQ8ePIIj3ajwi+9b4a0vdyYvh6uJKYibU8R1zrUIpCmCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/koa": "*"
+      }
+    },
+    "node_modules/@types/koa-compose": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.9.tgz",
+      "integrity": "sha512-BroAZ9FTvPiCy0Pi8tjD1OfJ7bgU1gQf0eR6e1Vm+JJATy9eKOG3hQMFtMciMawiSOVnLMdmUOC46s7HBhSTsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/koa": "*"
+      }
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
@@ -6096,6 +6288,41 @@
       "license": "MIT",
       "dependencies": {
         "pino": "*"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/shimmer": {
@@ -7264,6 +7491,112 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/co-body": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.2.0.tgz",
+      "integrity": "sha512-Kbpv2Yd1NdL1V/V4cwLVxraHDV6K8ayohr2rmH0J87Er8+zJjcTa6dAn9QMPC9CRgU8+aNajKbSf1TzDB1yKPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hapi/bourne": "^3.0.0",
+        "inflation": "^2.0.0",
+        "qs": "^6.5.2",
+        "raw-body": "^2.3.3",
+        "type-is": "^1.6.16"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/co-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/co-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/co-body/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/co-body/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/co-body/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/co-body/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/co-body/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7345,6 +7678,19 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/copy-anything": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
@@ -7360,6 +7706,12 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
+    },
+    "node_modules/copy-to": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
+      "integrity": "sha512-3DdaFaU/Zf1AnpLiFDeNCD4TOWe3Zl2RZaTzUvWiIk5ERzcCodOE20Vqq4fzCbNoHURFHT4/us/Lfq+S2zyY4w==",
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -7431,11 +7783,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT"
     },
     "node_modules/denque": {
@@ -7464,6 +7828,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/devlop": {
@@ -8505,6 +8879,53 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -8602,6 +9023,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflation": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.1.0.tgz",
+      "integrity": "sha512-t54PPJHG1Pp7VQvxyVCJ9mBbjG3Hqryges9bXoOO6GExCPa+//i/d5GSuFtpx3ALLd7lgIAur6zrIlBQyJuMlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/inherits": {
@@ -8865,6 +9295,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8873,6 +9316,162 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/koa": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.1.1.tgz",
+      "integrity": "sha512-KDDuvpfqSK0ZKEO2gCPedNjl5wYpfj+HNiuVRlbhd1A88S3M0ySkdf2V/EJ4NWt5dwh5PXCdcenrKK2IQJAxsg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~0.5.4",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-bodyparser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-4.4.1.tgz",
+      "integrity": "sha512-kBH3IYPMb+iAXnrxIhXnW+gXV8OTzCu8VPDqvcDHW9SQrbkHmqPQtiZwrltNmSq6/lpipHnT7k7PsjlVD7kK0w==",
+      "license": "MIT",
+      "dependencies": {
+        "co-body": "^6.0.0",
+        "copy-to": "^2.0.1",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/koa-bodyparser/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa-bodyparser/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa-bodyparser/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa-bodyparser/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/levn": {
@@ -9174,15 +9773,19 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -10882,6 +11485,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/tsx": {
       "version": "4.20.6",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "@aws-sdk/client-s3": "^3.922.0",
     "@aws-sdk/credential-providers": "^3.927.0",
     "@aws-sdk/s3-request-presigner": "^3.922.0",
+    "@koa/cors": "^5.0.0",
+    "@koa/router": "^13.1.0",
     "@modelcontextprotocol/sdk": "^1.19.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.48.0",
@@ -86,6 +88,8 @@
     "@supabase/supabase-js": "^2.74.0",
     "dotenv": "^16.4.0",
     "ioredis": "^5.4.1",
+    "koa": "^3.1.1",
+    "koa-bodyparser": "^4.4.1",
     "p-limit": "^7.2.0",
     "pino": "^10.1.0",
     "pino-pretty": "^13.1.3",
@@ -93,6 +97,10 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@types/koa": "^2.15.0",
+    "@types/koa__cors": "^5.0.0",
+    "@types/koa__router": "^12.0.4",
+    "@types/koa-bodyparser": "^4.3.12",
     "@types/node": "^24.7.0",
     "@types/pino": "^7.0.4",
     "@typescript-eslint/eslint-plugin": "^8.46.0",

--- a/scripts/seed-test-vcons.ts
+++ b/scripts/seed-test-vcons.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env npx tsx
+/**
+ * Seed database with test vCons
+ */
+
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { getSupabaseClient } from '../src/db/client.js';
+import { VConQueries } from '../src/db/queries.js';
+import { PluginManager } from '../src/hooks/plugin-manager.js';
+import { VConService } from '../src/services/vcon-service.js';
+import type { VCon } from '../src/types/vcon.js';
+
+async function seedDatabase() {
+  const supabase = getSupabaseClient();
+  const queries = new VConQueries(supabase, null);
+  const pluginManager = new PluginManager();
+  const vconService = new VConService({ queries, pluginManager });
+
+  const testVCons: Partial<VCon>[] = [
+    {
+      subject: 'Customer Support Call - Order Issue',
+      parties: [
+        { name: 'John Smith', tel: '+1-555-0101', mailto: 'john.smith@example.com' },
+        { name: 'Support Agent Sarah', tel: '+1-800-555-0199' }
+      ],
+      dialog: [
+        { type: 'text', start_time: '2025-12-29T10:00:00Z', parties: [0, 1], body: 'Hi, I have an issue with my order #12345', encoding: 'none' },
+        { type: 'text', start_time: '2025-12-29T10:01:00Z', parties: [1, 0], body: 'I would be happy to help you with that. Let me look up your order.', encoding: 'none' }
+      ],
+      analysis: [
+        { type: 'summary', vendor: 'openai', body: 'Customer called about order #12345 delivery delay. Agent provided tracking info.', encoding: 'none' },
+        { type: 'sentiment', vendor: 'openai', body: 'Customer: frustrated initially, satisfied after resolution', encoding: 'none' }
+      ]
+    },
+    {
+      subject: 'Sales Inquiry - Enterprise Plan',
+      parties: [
+        { name: 'Alice Johnson', tel: '+1-555-0202', mailto: 'alice@bigcorp.com' },
+        { name: 'Sales Rep Mike', tel: '+1-800-555-0200' }
+      ],
+      dialog: [
+        { type: 'text', start_time: '2025-12-29T14:00:00Z', parties: [0, 1], body: 'We are interested in your enterprise plan for 500 users', encoding: 'none' }
+      ],
+      analysis: [
+        { type: 'summary', vendor: 'internal', body: 'Enterprise sales inquiry from BigCorp for 500 seats', encoding: 'none' }
+      ]
+    },
+    {
+      subject: 'Technical Support - API Integration',
+      parties: [
+        { name: 'Dev Team Lead', mailto: 'devlead@startup.io' },
+        { name: 'Technical Support', tel: '+1-800-555-0300' }
+      ],
+      dialog: [
+        { type: 'text', start_time: '2025-12-29T09:30:00Z', parties: [0, 1], body: 'Having issues with the REST API authentication', encoding: 'none' },
+        { type: 'text', start_time: '2025-12-29T09:32:00Z', parties: [1, 0], body: 'Please check that your API key has the correct permissions', encoding: 'none' }
+      ],
+      analysis: [
+        { type: 'transcript', vendor: 'whisper', body: 'Technical call regarding API authentication issues', encoding: 'none' }
+      ]
+    },
+    {
+      subject: 'Product Demo Request',
+      parties: [
+        { name: 'Prospect Company', mailto: 'info@prospect.com' }
+      ],
+      dialog: [],
+      analysis: []
+    },
+    {
+      subject: 'Billing Question - Invoice #98765',
+      parties: [
+        { name: 'Finance Dept', tel: '+1-555-0303' },
+        { name: 'Billing Support', tel: '+1-800-555-0400' }
+      ],
+      dialog: [
+        { type: 'text', start_time: '2025-12-29T11:00:00Z', parties: [0, 1], body: 'Question about invoice #98765 charges', encoding: 'none' }
+      ]
+    }
+  ];
+
+  console.log('🌱 Seeding database with test vCons...\n');
+  
+  for (const vcon of testVCons) {
+    try {
+      const result = await vconService.create(vcon, { source: 'seed-script' });
+      console.log(`✅ Created: ${result.uuid} - ${vcon.subject}`);
+    } catch (error: any) {
+      console.error(`❌ Failed: ${vcon.subject} - ${error.message}`);
+    }
+  }
+
+  // Verify by listing
+  const { data } = await supabase
+    .from('vcons')
+    .select('id, uuid, subject')
+    .order('created_at', { ascending: false });
+  
+  console.log('\n📋 All vCons in database:');
+  console.log('ID === UUID verification:');
+  for (const v of data || []) {
+    const match = v.id === v.uuid ? '✅' : '❌';
+    console.log(`  ${match} ${v.uuid} - ${v.subject}`);
+  }
+  console.log(`\nTotal: ${data?.length || 0} vCons`);
+}
+
+seedDatabase().catch(console.error);
+

--- a/scripts/test-api-integration.ts
+++ b/scripts/test-api-integration.ts
@@ -1,0 +1,226 @@
+#!/usr/bin/env npx tsx
+/**
+ * Integration test for VConService and REST API
+ * 
+ * Tests vCon ingestion and retrieval without starting the full server
+ */
+
+import dotenv from 'dotenv';
+import { getSupabaseClient } from '../src/db/client.js';
+import { VConQueries } from '../src/db/queries.js';
+import { PluginManager } from '../src/hooks/plugin-manager.js';
+import { VConService } from '../src/services/vcon-service.js';
+import type { VCon } from '../src/types/vcon.js';
+
+// Load environment
+dotenv.config();
+
+async function main() {
+  console.log('🧪 Starting VConService Integration Test\n');
+
+  // Initialize dependencies
+  console.log('1️⃣  Initializing database client...');
+  const supabase = getSupabaseClient();
+  const queries = new VConQueries(supabase, null);
+  const pluginManager = new PluginManager();
+  
+  // Create VConService
+  const vconService = new VConService({ queries, pluginManager });
+  console.log('   ✅ VConService initialized\n');
+
+  // Test 1: Create a vCon
+  console.log('2️⃣  Creating a test vCon...');
+  const testVCon: Partial<VCon> = {
+    subject: `Integration Test - ${new Date().toISOString()}`,
+    parties: [
+      { name: 'Alice', tel: '+1-555-0100' },
+      { name: 'Bob', tel: '+1-555-0200' },
+    ],
+    dialog: [
+      {
+        type: 'text',
+        start_time: new Date().toISOString(),
+        parties: [0, 1],
+        body: 'Hello, this is a test message from the integration test.',
+        encoding: 'none',
+      },
+    ],
+    analysis: [
+      {
+        type: 'summary',
+        vendor: 'integration-test',
+        body: 'This is a test vCon created by the integration test script.',
+        encoding: 'none',
+      },
+    ],
+  };
+
+  let createdUuid: string;
+  try {
+    const result = await vconService.create(testVCon, { source: 'integration-test' });
+    createdUuid = result.uuid;
+    console.log(`   ✅ vCon created with UUID: ${createdUuid}`);
+    console.log(`   📝 Subject: ${result.vcon.subject}\n`);
+  } catch (error) {
+    console.error('   ❌ Failed to create vCon:', error);
+    process.exit(1);
+  }
+
+  // Test 2: Retrieve the vCon
+  console.log('3️⃣  Retrieving the vCon...');
+  try {
+    const retrieved = await vconService.get(createdUuid);
+    console.log(`   ✅ vCon retrieved successfully`);
+    console.log(`   📝 UUID: ${retrieved.uuid}`);
+    console.log(`   📝 Subject: ${retrieved.subject}`);
+    console.log(`   📝 Parties: ${retrieved.parties?.length || 0}`);
+    console.log(`   📝 Dialog entries: ${retrieved.dialog?.length || 0}`);
+    console.log(`   📝 Analysis entries: ${retrieved.analysis?.length || 0}\n`);
+  } catch (error) {
+    console.error('   ❌ Failed to retrieve vCon:', error);
+    process.exit(1);
+  }
+
+  // Test 3: Search for the vCon
+  console.log('4️⃣  Searching for vCons with "Integration Test"...');
+  try {
+    const searchResults = await vconService.search({ subject: 'Integration Test', limit: 5 });
+    console.log(`   ✅ Found ${searchResults.length} matching vCon(s)`);
+    for (const vcon of searchResults) {
+      console.log(`      - ${vcon.uuid}: ${vcon.subject}`);
+    }
+    console.log();
+  } catch (error) {
+    console.error('   ❌ Search failed:', error);
+  }
+
+  // Test 4: Create batch vCons
+  console.log('5️⃣  Creating batch of 3 vCons...');
+  const batchVCons: Partial<VCon>[] = [
+    {
+      subject: `Batch Test 1 - ${new Date().toISOString()}`,
+      parties: [{ name: 'Batch User 1' }],
+    },
+    {
+      subject: `Batch Test 2 - ${new Date().toISOString()}`,
+      parties: [{ name: 'Batch User 2' }],
+    },
+    {
+      subject: `Batch Test 3 - ${new Date().toISOString()}`,
+      parties: [{ name: 'Batch User 3' }],
+    },
+  ];
+
+  try {
+    const batchResult = await vconService.createBatch(batchVCons, { source: 'integration-test-batch' });
+    console.log(`   ✅ Batch create completed`);
+    console.log(`      Total: ${batchResult.total}`);
+    console.log(`      Created: ${batchResult.created}`);
+    console.log(`      Failed: ${batchResult.failed}`);
+    for (const r of batchResult.results) {
+      console.log(`      - ${r.uuid}: ${r.success ? '✅' : '❌ ' + r.error}`);
+    }
+    console.log();
+  } catch (error) {
+    console.error('   ❌ Batch create failed:', error);
+  }
+
+  // Test 5: Delete the test vCon
+  console.log('6️⃣  Cleaning up - deleting test vCon...');
+  try {
+    const deleted = await vconService.delete(createdUuid, { source: 'integration-test-cleanup' });
+    if (deleted) {
+      console.log(`   ✅ vCon ${createdUuid} deleted successfully\n`);
+    } else {
+      console.log(`   ⚠️ vCon not found for deletion\n`);
+    }
+  } catch (error) {
+    console.error('   ❌ Delete failed:', error);
+  }
+
+  // Test 6: Verify deletion
+  console.log('7️⃣  Verifying deletion...');
+  try {
+    await vconService.get(createdUuid);
+    console.log('   ⚠️ vCon still exists (unexpected)\n');
+  } catch (error) {
+    console.log('   ✅ vCon no longer exists (expected)\n');
+  }
+
+  // Test 8: Test MCP tool handlers
+  console.log('8️⃣  Testing MCP Tool Handlers...');
+  
+  // Import tool handlers
+  const { CreateVConHandler, GetVConHandler, DeleteVConHandler } = await import('../src/tools/handlers/vcon-crud.js');
+  const { DatabaseInspector } = await import('../src/db/database-inspector.js');
+  const { DatabaseAnalytics } = await import('../src/db/database-analytics.js');
+  const { DatabaseSizeAnalyzer } = await import('../src/db/database-size-analyzer.js');
+  
+  // Create handler context
+  const dbInspector = new DatabaseInspector(supabase);
+  const dbAnalytics = new DatabaseAnalytics(supabase);
+  const dbSizeAnalyzer = new DatabaseSizeAnalyzer(supabase);
+  
+  const handlerContext = {
+    queries,
+    pluginManager,
+    dbInspector,
+    dbAnalytics,
+    dbSizeAnalyzer,
+    supabase,
+    vconService,
+  };
+  
+  // Test CreateVConHandler
+  console.log('   📋 Testing CreateVConHandler...');
+  const createHandler = new CreateVConHandler();
+  try {
+    const createResult = await createHandler.handle(
+      { subject: 'MCP Tool Handler Test', parties: [{ name: 'MCP Test User' }] },
+      handlerContext
+    );
+    const createResponse = JSON.parse(createResult.content[0].text);
+    console.log(`      ✅ Created via MCP tool: ${createResponse.uuid}`);
+    
+    // Test GetVConHandler
+    console.log('   📋 Testing GetVConHandler...');
+    const getHandler = new GetVConHandler();
+    const getResult = await getHandler.handle(
+      { uuid: createResponse.uuid },
+      handlerContext
+    );
+    const getResponse = JSON.parse(getResult.content[0].text);
+    console.log(`      ✅ Retrieved via MCP tool: ${getResponse.vcon.subject}`);
+    
+    // Test DeleteVConHandler
+    console.log('   📋 Testing DeleteVConHandler...');
+    const deleteHandler = new DeleteVConHandler();
+    const deleteResult = await deleteHandler.handle(
+      { uuid: createResponse.uuid },
+      handlerContext
+    );
+    const deleteResponse = JSON.parse(deleteResult.content[0].text);
+    console.log(`      ✅ Deleted via MCP tool: ${deleteResponse.message}`);
+  } catch (error) {
+    console.error('   ❌ MCP tool handler test failed:', error);
+  }
+
+  console.log('\n🎉 Integration test completed!\n');
+  console.log('Summary:');
+  console.log('  ✅ VConService.create() - working');
+  console.log('  ✅ VConService.get() - working');
+  console.log('  ✅ VConService.search() - working');
+  console.log('  ✅ VConService.createBatch() - working');
+  console.log('  ✅ VConService.delete() - working');
+  console.log('  ✅ MCP CreateVConHandler - working');
+  console.log('  ✅ MCP GetVConHandler - working');
+  console.log('  ✅ MCP DeleteVConHandler - working');
+  console.log('\nAll lifecycle hooks are executed automatically by VConService.');
+  console.log('REST API and MCP tools both use VConService for consistent behavior.');
+}
+
+main().catch((error) => {
+  console.error('❌ Test failed:', error);
+  process.exit(1);
+});
+

--- a/scripts/test-tenant-isolation.ts
+++ b/scripts/test-tenant-isolation.ts
@@ -99,10 +99,12 @@ async function main() {
 
   await test('Create test vCons with different tenants', async () => {
     // Create vCon for tenant1
+    const uuid1 = randomUUID();
     const { data: vcon1, error: e1 } = await serviceRoleClient
       .from('vcons')
       .insert({
-        uuid: randomUUID(),
+        id: uuid1,  // Set id = uuid
+        uuid: uuid1,
         vcon_version: '0.3.0',
         subject: 'Test vCon for Tenant 1',
         tenant_id: 'tenant-1',
@@ -114,10 +116,12 @@ async function main() {
     tenant1VconId = vcon1.id;
 
     // Create vCon for tenant2
+    const uuid2 = randomUUID();
     const { data: vcon2, error: e2 } = await serviceRoleClient
       .from('vcons')
       .insert({
-        uuid: randomUUID(),
+        id: uuid2,  // Set id = uuid
+        uuid: uuid2,
         vcon_version: '0.3.0',
         subject: 'Test vCon for Tenant 2',
         tenant_id: 'tenant-2',
@@ -129,10 +133,12 @@ async function main() {
     tenant2VconId = vcon2.id;
 
     // Create shared vCon (NULL tenant_id)
+    const uuid3 = randomUUID();
     const { data: vcon3, error: e3 } = await serviceRoleClient
       .from('vcons')
       .insert({
-        uuid: randomUUID(),
+        id: uuid3,  // Set id = uuid
+        uuid: uuid3,
         vcon_version: '0.3.0',
         subject: 'Shared vCon (NULL tenant)',
         tenant_id: null,

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,141 @@
+/**
+ * REST API Authentication Middleware for Koa
+ * 
+ * Provides API key authentication for REST endpoints
+ */
+
+import type { Context, Next } from 'koa';
+import { logWithContext } from '../observability/instrumentation.js';
+
+export interface AuthConfig {
+  /** API keys that are allowed (comma-separated in env) */
+  apiKeys: string[];
+  /** Header name for API key (default: x-api-key) */
+  headerName: string;
+  /** Whether auth is required (default: true) */
+  required: boolean;
+}
+
+/**
+ * Get auth configuration from environment
+ */
+export function getAuthConfig(): AuthConfig {
+  const apiKeysEnv = process.env.VCON_API_KEYS || process.env.API_KEYS || '';
+  const apiKeys = apiKeysEnv
+    .split(',')
+    .map(k => k.trim())
+    .filter(k => k.length > 0);
+
+  return {
+    apiKeys,
+    headerName: process.env.API_KEY_HEADER || 'x-api-key',
+    required: process.env.API_AUTH_REQUIRED !== 'false',
+  };
+}
+
+/**
+ * Koa authentication middleware factory
+ */
+export function createAuthMiddleware(config?: Partial<AuthConfig>) {
+  const authConfig: AuthConfig = { ...getAuthConfig(), ...config };
+
+  return async (ctx: Context, next: Next) => {
+    // If auth not required and no keys configured, allow all
+    if (!authConfig.required && authConfig.apiKeys.length === 0) {
+      await next();
+      return;
+    }
+
+    // Get API key from header
+    const apiKey = ctx.get(authConfig.headerName);
+
+    if (!apiKey) {
+      ctx.status = 401;
+      ctx.set('WWW-Authenticate', 'ApiKey realm="vCon API"');
+      ctx.body = {
+        error: 'Unauthorized',
+        message: `Missing ${authConfig.headerName} header`,
+      };
+      return;
+    }
+
+    // Check if API key is valid
+    if (!authConfig.apiKeys.includes(apiKey)) {
+      logWithContext('warn', 'Invalid API key attempted', {
+        remote_address: ctx.ip,
+        api_key_prefix: apiKey.substring(0, 8) + '...',
+      });
+
+      ctx.status = 401;
+      ctx.set('WWW-Authenticate', 'ApiKey realm="vCon API"');
+      ctx.body = {
+        error: 'Unauthorized',
+        message: 'Invalid API key',
+      };
+      return;
+    }
+
+    // Store API key in state for downstream use
+    ctx.state.apiKey = apiKey;
+    await next();
+  };
+}
+
+/**
+ * Error handling middleware for Koa
+ */
+export function errorHandler() {
+  return async (ctx: Context, next: Next) => {
+    try {
+      await next();
+    } catch (err: any) {
+      const status = err.status || err.statusCode || 500;
+      const message = err.message || 'Internal Server Error';
+
+      logWithContext('error', 'REST API error', {
+        status,
+        message,
+        path: ctx.path,
+        method: ctx.method,
+        error_stack: err.stack,
+      });
+
+      ctx.status = status;
+      ctx.body = {
+        error: status >= 500 ? 'Internal Server Error' : 'Error',
+        message: status >= 500 && process.env.NODE_ENV === 'production' 
+          ? 'An unexpected error occurred' 
+          : message,
+        timestamp: new Date().toISOString(),
+      };
+    }
+  };
+}
+
+/**
+ * Request logging middleware for Koa
+ */
+export function requestLogger() {
+  return async (ctx: Context, next: Next) => {
+    const startTime = Date.now();
+
+    logWithContext('info', 'REST API request', {
+      method: ctx.method,
+      path: ctx.path,
+      query: ctx.querystring || undefined,
+      remote_address: ctx.ip,
+      user_agent: ctx.get('user-agent'),
+    });
+
+    await next();
+
+    const duration = Date.now() - startTime;
+
+    logWithContext('info', 'REST API response', {
+      method: ctx.method,
+      path: ctx.path,
+      status: ctx.status,
+      duration_ms: duration,
+    });
+  };
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,11 @@
+/**
+ * REST API Module
+ * 
+ * Exports Koa-based REST API components for vCon ingestion and operations
+ */
+
+export { createAuthMiddleware, errorHandler, getAuthConfig, requestLogger } from './auth.js';
+export type { AuthConfig } from './auth.js';
+
+export { createRestApi, getRestApiConfig, isRestApiPath } from './rest-router.js';
+export type { RestApiConfig, RestApiContext } from './rest-router.js';

--- a/src/api/rest-router.ts
+++ b/src/api/rest-router.ts
@@ -189,8 +189,11 @@ async function getVCon(ctx: Context, apiContext: RestApiContext) {
 async function listVCons(ctx: Context, apiContext: RestApiContext) {
   const limit = Math.min(100, parseInt(ctx.query.limit as string) || 10);
 
-  // Use searchVCons with empty filters to get recent vCons
-  const vcons = await apiContext.queries.searchVCons({ limit });
+  // Use VConService for consistent lifecycle handling (beforeSearch/afterSearch hooks)
+  const vcons = await apiContext.vconService.search(
+    { limit },
+    { requestContext: { purpose: 'rest-api-list' } }
+  );
 
   ctx.body = {
     success: true,

--- a/src/api/rest-router.ts
+++ b/src/api/rest-router.ts
@@ -1,0 +1,328 @@
+/**
+ * REST API Router using Koa
+ * 
+ * Clean, declarative REST API for vCon operations.
+ * Uses VConService for consistent lifecycle handling.
+ */
+
+import Koa from 'koa';
+import Router from '@koa/router';
+import bodyParser from 'koa-bodyparser';
+import cors from '@koa/cors';
+import type { Context } from 'koa';
+import { VConQueries } from '../db/queries.js';
+import { PluginManager } from '../hooks/plugin-manager.js';
+import { logWithContext, recordCounter } from '../observability/instrumentation.js';
+import { VConService, VConValidationError } from '../services/vcon-service.js';
+import { VCon } from '../types/vcon.js';
+import { createAuthMiddleware, errorHandler, getAuthConfig, requestLogger } from './auth.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RestApiContext {
+  queries: VConQueries;
+  pluginManager: PluginManager;
+  supabase: any;
+  vconService: VConService;
+}
+
+export interface RestApiConfig {
+  /** Base path for REST API (default: /api/v1) */
+  basePath: string;
+  /** Enable REST API (default: true when HTTP enabled) */
+  enabled: boolean;
+  /** CORS origin (default: *) */
+  corsOrigin: string;
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+export function getRestApiConfig(): RestApiConfig {
+  return {
+    basePath: process.env.REST_API_BASE_PATH || '/api/v1',
+    enabled: process.env.REST_API_ENABLED !== 'false',
+    corsOrigin: process.env.CORS_ORIGIN || '*',
+  };
+}
+
+// ============================================================================
+// Route Handlers
+// ============================================================================
+
+/**
+ * POST /vcons - Create/Ingest a single vCon
+ */
+async function createVCon(ctx: Context, apiContext: RestApiContext) {
+  const startTime = Date.now();
+  
+  // Body can be the vCon directly or wrapped in { vcon: ... }
+  const body = ctx.request.body as any;
+  const vconData: Partial<VCon> = body.vcon || body;
+
+  try {
+    // Use VConService for consistent lifecycle handling
+    const result = await apiContext.vconService.create(vconData, {
+      requestContext: { purpose: 'rest-api-ingest' },
+      source: 'rest-api',
+    });
+
+    const duration = Date.now() - startTime;
+    logWithContext('info', 'vCon created via REST API', {
+      uuid: result.uuid,
+      duration_ms: duration,
+      parties_count: result.vcon.parties?.length || 0,
+      dialog_count: result.vcon.dialog?.length || 0,
+      analysis_count: result.vcon.analysis?.length || 0,
+    });
+
+    ctx.status = 201;
+    ctx.body = {
+      success: true,
+      uuid: result.uuid,
+      id: result.id,
+      message: 'vCon created successfully',
+      duration_ms: duration,
+    };
+  } catch (error) {
+    if (error instanceof VConValidationError) {
+      ctx.status = 400;
+      ctx.body = {
+        error: 'Validation Error',
+        message: error.errors.join('; '),
+      };
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * POST /vcons/batch - Batch ingest multiple vCons
+ */
+async function batchCreateVCons(ctx: Context, apiContext: RestApiContext) {
+  const startTime = Date.now();
+  
+  const body = ctx.request.body as any;
+  const vcons: Partial<VCon>[] = body.vcons || body;
+
+  if (!Array.isArray(vcons)) {
+    ctx.status = 400;
+    ctx.body = {
+      error: 'Validation Error',
+      message: 'Request body must be an array of vCons or { vcons: [...] }',
+    };
+    return;
+  }
+
+  if (vcons.length === 0) {
+    ctx.status = 400;
+    ctx.body = { error: 'Validation Error', message: 'Empty vCons array' };
+    return;
+  }
+
+  if (vcons.length > 100) {
+    ctx.status = 400;
+    ctx.body = { error: 'Validation Error', message: 'Maximum 100 vCons per batch' };
+    return;
+  }
+
+  // Use VConService batch create for consistent lifecycle handling
+  const batchResult = await apiContext.vconService.createBatch(vcons, {
+    requestContext: { purpose: 'rest-api-batch-ingest' },
+    source: 'rest-api-batch',
+  });
+
+  const duration = Date.now() - startTime;
+  
+  logWithContext('info', 'Batch vCon creation completed', {
+    total: batchResult.total,
+    success: batchResult.created,
+    errors: batchResult.failed,
+    duration_ms: duration,
+  });
+
+  ctx.status = batchResult.failed === 0 ? 201 : 207; // 207 Multi-Status if partial success
+  ctx.body = {
+    success: batchResult.failed === 0,
+    total: batchResult.total,
+    created: batchResult.created,
+    failed: batchResult.failed,
+    results: batchResult.results,
+    duration_ms: duration,
+  };
+}
+
+/**
+ * GET /vcons/:uuid - Get a vCon by UUID
+ */
+async function getVCon(ctx: Context, apiContext: RestApiContext) {
+  const uuid = ctx.params.uuid;
+
+  try {
+    // Use VConService for consistent lifecycle handling
+    const vcon = await apiContext.vconService.get(uuid, {
+      requestContext: { purpose: 'rest-api-read' },
+    });
+
+    ctx.body = {
+      success: true,
+      vcon,
+    };
+  } catch (error) {
+    // VConService throws if not found
+    if (error instanceof Error && error.message.includes('not found')) {
+      ctx.status = 404;
+      ctx.body = { error: 'Not Found', message: `vCon with UUID ${uuid} not found` };
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * GET /vcons - List recent vCons
+ */
+async function listVCons(ctx: Context, apiContext: RestApiContext) {
+  const limit = Math.min(100, parseInt(ctx.query.limit as string) || 10);
+
+  // Use searchVCons with empty filters to get recent vCons
+  const vcons = await apiContext.queries.searchVCons({ limit });
+
+  ctx.body = {
+    success: true,
+    count: vcons.length,
+    limit,
+    vcons,
+  };
+}
+
+/**
+ * DELETE /vcons/:uuid - Delete a vCon
+ */
+async function deleteVCon(ctx: Context, apiContext: RestApiContext) {
+  const uuid = ctx.params.uuid;
+
+  // Use VConService for consistent lifecycle handling
+  const deleted = await apiContext.vconService.delete(uuid, {
+    requestContext: { purpose: 'rest-api-delete' },
+    source: 'rest-api',
+  });
+
+  if (!deleted) {
+    ctx.status = 404;
+    ctx.body = { error: 'Not Found', message: `vCon with UUID ${uuid} not found` };
+    return;
+  }
+
+  ctx.body = {
+    success: true,
+    message: `vCon ${uuid} deleted successfully`,
+  };
+}
+
+/**
+ * GET /health - Health check endpoint
+ */
+async function healthCheck(ctx: Context, apiContext: RestApiContext) {
+  try {
+    // Quick DB check
+    const { error } = await apiContext.supabase
+      .from('vcons')
+      .select('id', { count: 'exact', head: true })
+      .limit(1);
+
+    if (error) throw error;
+
+    ctx.body = {
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+      database: 'connected',
+    };
+  } catch (error) {
+    ctx.status = 503;
+    ctx.body = {
+      status: 'unhealthy',
+      timestamp: new Date().toISOString(),
+      database: 'error',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+// ============================================================================
+// Koa App Factory
+// ============================================================================
+
+/**
+ * Create Koa app with REST API routes
+ */
+export function createRestApi(apiContext: RestApiContext, config?: Partial<RestApiConfig>): Koa {
+  const restConfig: RestApiConfig = { ...getRestApiConfig(), ...config };
+  const authConfig = getAuthConfig();
+
+  const app = new Koa();
+  const router = new Router({ prefix: restConfig.basePath });
+
+  // ========== Global Middleware ==========
+  
+  // Error handling (must be first)
+  app.use(errorHandler());
+
+  // Request logging
+  app.use(requestLogger());
+
+  // CORS
+  app.use(cors({
+    origin: restConfig.corsOrigin,
+    allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    allowHeaders: ['Content-Type', 'x-api-key', 'Authorization'],
+  }));
+
+  // Body parser (50MB limit for batch operations)
+  app.use(bodyParser({
+    jsonLimit: '50mb',
+    enableTypes: ['json'],
+  }));
+
+  // Authentication (skip for health endpoint)
+  app.use(async (ctx: Context, next: () => Promise<void>) => {
+    // Skip auth for health check
+    if (ctx.path === `${restConfig.basePath}/health`) {
+      await next();
+      return;
+    }
+    
+    // Apply auth middleware
+    const authMiddleware = createAuthMiddleware(authConfig);
+    await authMiddleware(ctx, next);
+  });
+
+  // ========== Routes ==========
+
+  // Health check (no auth required)
+  router.get('/health', async (ctx: Context) => { await healthCheck(ctx, apiContext); });
+
+  // vCon CRUD operations
+  router.post('/vcons', async (ctx: Context) => { await createVCon(ctx, apiContext); });
+  router.post('/vcons/batch', async (ctx: Context) => { await batchCreateVCons(ctx, apiContext); });
+  router.get('/vcons', async (ctx: Context) => { await listVCons(ctx, apiContext); });
+  router.get('/vcons/:uuid', async (ctx: Context) => { await getVCon(ctx, apiContext); });
+  router.delete('/vcons/:uuid', async (ctx: Context) => { await deleteVCon(ctx, apiContext); });
+
+  // Apply routes
+  app.use(router.routes());
+  app.use(router.allowedMethods());
+
+  return app;
+}
+
+/**
+ * Check if request path is for REST API
+ */
+export function isRestApiPath(path: string, basePath: string = '/api/v1'): boolean {
+  return path.startsWith(basePath);
+}

--- a/src/server/setup.ts
+++ b/src/server/setup.ts
@@ -13,6 +13,7 @@ import { VConQueries } from '../db/queries.js';
 import { debugTenantVisibility, setTenantContext, verifyTenantContext } from '../db/tenant-context.js';
 import { PluginManager } from '../hooks/plugin-manager.js';
 import { createLogger } from '../observability/logger.js';
+import { VConService } from '../services/vcon-service.js';
 import { createHandlerRegistry, type ToolHandlerRegistry } from '../tools/handlers/index.js';
 
 const logger = createLogger('server-setup');
@@ -27,6 +28,7 @@ export interface ServerContext {
   redis: any;
   pluginManager: PluginManager;
   handlerRegistry: ToolHandlerRegistry;
+  vconService: VConService;
 }
 
 /**
@@ -177,6 +179,12 @@ export async function setupServer(): Promise<ServerContext> {
   // Initialize tool handler registry
   const handlerRegistry = createHandlerRegistry();
 
+  // Initialize vCon service (single source of truth for vCon lifecycle)
+  const vconService = new VConService({
+    queries,
+    pluginManager,
+  });
+
   return {
     server,
     queries,
@@ -187,5 +195,6 @@ export async function setupServer(): Promise<ServerContext> {
     redis,
     pluginManager,
     handlerRegistry,
+    vconService,
   };
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Services Module
+ * 
+ * Exports service layer components for vCon operations
+ */
+
+export {
+  VConService,
+  VConValidationError,
+  VConNotFoundError,
+} from './vcon-service.js';
+
+export type {
+  VConServiceContext,
+  CreateVConOptions,
+  CreateVConResult,
+  BatchCreateResult,
+  BatchCreateVConsResult,
+  GetVConOptions,
+  DeleteVConOptions,
+} from './vcon-service.js';
+

--- a/src/services/vcon-service.ts
+++ b/src/services/vcon-service.ts
@@ -1,0 +1,352 @@
+/**
+ * VCon Service
+ * 
+ * Encapsulates vCon lifecycle operations with hooks, validation, and metrics.
+ * This service is the single source of truth for vCon CRUD operations,
+ * ensuring consistent behavior across MCP tools and REST API.
+ */
+
+import { randomUUID } from 'crypto';
+import { VConQueries } from '../db/queries.js';
+import { PluginManager } from '../hooks/plugin-manager.js';
+import { RequestContext } from '../hooks/plugin-interface.js';
+import { ATTR_VCON_UUID } from '../observability/attributes.js';
+import { logWithContext, recordCounter } from '../observability/instrumentation.js';
+import { VCon } from '../types/vcon.js';
+import { validateVCon } from '../utils/validation.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface VConServiceContext {
+  queries: VConQueries;
+  pluginManager: PluginManager;
+}
+
+export interface CreateVConOptions {
+  /** Skip beforeCreate/afterCreate hooks */
+  skipHooks?: boolean;
+  /** Skip validation */
+  skipValidation?: boolean;
+  /** Custom request context for hooks (timestamp auto-populated if missing) */
+  requestContext?: Partial<RequestContext>;
+  /** Source identifier for metrics (e.g., 'mcp', 'rest-api', 'batch') */
+  source?: string;
+}
+
+export interface CreateVConResult {
+  uuid: string;
+  id: string;
+  vcon: VCon;
+}
+
+export interface BatchCreateResult {
+  uuid: string;
+  success: boolean;
+  id?: string;
+  error?: string;
+}
+
+export interface BatchCreateVConsResult {
+  total: number;
+  created: number;
+  failed: number;
+  results: BatchCreateResult[];
+}
+
+export interface GetVConOptions {
+  /** Skip beforeRead/afterRead hooks */
+  skipHooks?: boolean;
+  /** Custom request context for hooks (timestamp auto-populated if missing) */
+  requestContext?: Partial<RequestContext>;
+}
+
+export interface DeleteVConOptions {
+  /** Skip beforeDelete/afterDelete hooks */
+  skipHooks?: boolean;
+  /** Custom request context for hooks (timestamp auto-populated if missing) */
+  requestContext?: Partial<RequestContext>;
+  /** Source identifier for metrics */
+  source?: string;
+}
+
+// ============================================================================
+// VCon Service
+// ============================================================================
+
+export class VConService {
+  constructor(private context: VConServiceContext) {}
+
+  /**
+   * Normalize partial RequestContext to full RequestContext
+   */
+  private normalizeRequestContext(
+    partial?: Partial<RequestContext>,
+    defaultPurpose: string = 'vcon-service'
+  ): RequestContext {
+    return {
+      timestamp: new Date(),
+      purpose: defaultPurpose,
+      ...partial,
+    };
+  }
+
+  /**
+   * Create a new vCon with full lifecycle handling
+   * 
+   * This method:
+   * 1. Normalizes the vCon data (generates UUID, timestamps if missing)
+   * 2. Executes beforeCreate hooks (can modify or block)
+   * 3. Validates the vCon structure
+   * 4. Persists to database (handles denormalization)
+   * 5. Executes afterCreate hooks
+   * 6. Records metrics
+   */
+  async create(
+    vconData: Partial<VCon>,
+    options: CreateVConOptions = {}
+  ): Promise<CreateVConResult> {
+    const startTime = Date.now();
+    const source = options.source || 'unknown';
+    const requestContext = this.normalizeRequestContext(options.requestContext, source);
+
+    // Step 1: Normalize vCon data
+    let vcon: VCon = this.normalizeVCon(vconData);
+
+    // Step 2: Execute beforeCreate hook
+    if (!options.skipHooks) {
+      const modifiedVCon = await this.context.pluginManager.executeHook<VCon>(
+        'beforeCreate', vcon, requestContext
+      );
+      if (modifiedVCon) {
+        vcon = modifiedVCon;
+      }
+    }
+
+    // Step 3: Validate
+    if (!options.skipValidation) {
+      const validation = validateVCon(vcon);
+      if (!validation.valid) {
+        throw new VConValidationError(validation.errors);
+      }
+    }
+
+    // Step 4: Persist to database
+    const result = await this.context.queries.createVCon(vcon);
+
+    // Step 5: Execute afterCreate hook
+    if (!options.skipHooks) {
+      await this.context.pluginManager.executeHook('afterCreate', vcon, requestContext);
+    }
+
+    // Step 6: Record metrics
+    const duration = Date.now() - startTime;
+    recordCounter('vcon.created.count', 1, {
+      [ATTR_VCON_UUID]: result.uuid,
+      source,
+    }, 'vCon creation count');
+
+    logWithContext('debug', 'vCon created', {
+      uuid: result.uuid,
+      source,
+      duration_ms: duration,
+      parties_count: vcon.parties?.length || 0,
+      dialog_count: vcon.dialog?.length || 0,
+      analysis_count: vcon.analysis?.length || 0,
+    });
+
+    return {
+      uuid: result.uuid,
+      id: result.id,
+      vcon,
+    };
+  }
+
+  /**
+   * Create multiple vCons in batch
+   * 
+   * Processes each vCon individually, collecting results.
+   * Continues processing even if some fail.
+   */
+  async createBatch(
+    vcons: Partial<VCon>[],
+    options: CreateVConOptions = {}
+  ): Promise<BatchCreateVConsResult> {
+    const results: BatchCreateResult[] = [];
+    let successCount = 0;
+    let errorCount = 0;
+
+    for (const vconData of vcons) {
+      try {
+        const result = await this.create(vconData, {
+          ...options,
+          source: options.source || 'batch',
+        });
+        results.push({
+          uuid: result.uuid,
+          success: true,
+          id: result.id,
+        });
+        successCount++;
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        results.push({
+          uuid: vconData.uuid || 'unknown',
+          success: false,
+          error: errorMsg,
+        });
+        errorCount++;
+      }
+    }
+
+    return {
+      total: vcons.length,
+      created: successCount,
+      failed: errorCount,
+      results,
+    };
+  }
+
+  /**
+   * Get a vCon by UUID with hook support
+   */
+  async get(uuid: string, options: GetVConOptions = {}): Promise<VCon> {
+    const requestContext = this.normalizeRequestContext(options.requestContext, 'read');
+
+    // Execute beforeRead hook (can throw to block)
+    if (!options.skipHooks) {
+      await this.context.pluginManager.executeHook('beforeRead', uuid, requestContext);
+    }
+
+    const vcon = await this.context.queries.getVCon(uuid);
+
+    // Execute afterRead hook (can modify response)
+    if (!options.skipHooks) {
+      const modifiedVCon = await this.context.pluginManager.executeHook<VCon>(
+        'afterRead', vcon, requestContext
+      );
+      if (modifiedVCon) {
+        return modifiedVCon;
+      }
+    }
+
+    return vcon;
+  }
+
+  /**
+   * Delete a vCon by UUID with hook support
+   * 
+   * @returns true if deleted, false if not found
+   */
+  async delete(uuid: string, options: DeleteVConOptions = {}): Promise<boolean> {
+    const source = options.source || 'unknown';
+    const requestContext = this.normalizeRequestContext(options.requestContext, 'delete');
+
+    // Check if vCon exists
+    try {
+      await this.context.queries.getVCon(uuid);
+    } catch {
+      return false; // Not found
+    }
+
+    // Execute beforeDelete hook (can throw to prevent)
+    if (!options.skipHooks) {
+      await this.context.pluginManager.executeHook('beforeDelete', uuid, requestContext);
+    }
+
+    // Delete from database
+    await this.context.queries.deleteVCon(uuid);
+
+    // Execute afterDelete hook
+    if (!options.skipHooks) {
+      await this.context.pluginManager.executeHook('afterDelete', uuid, requestContext);
+    }
+
+    // Record metrics
+    recordCounter('vcon.deleted.count', 1, {
+      [ATTR_VCON_UUID]: uuid,
+      source,
+    }, 'vCon deletion count');
+
+    return true;
+  }
+
+  /**
+   * Search vCons with hook support
+   */
+  async search(
+    filters: Parameters<VConQueries['searchVCons']>[0],
+    options: { requestContext?: Partial<RequestContext>; skipHooks?: boolean } = {}
+  ): Promise<VCon[]> {
+    const requestContext = this.normalizeRequestContext(options.requestContext, 'search');
+
+    // Execute beforeSearch hook (can modify criteria)
+    let searchFilters = filters;
+    if (!options.skipHooks) {
+      const modifiedFilters = await this.context.pluginManager.executeHook<typeof filters>(
+        'beforeSearch', filters, requestContext
+      );
+      if (modifiedFilters) {
+        searchFilters = modifiedFilters;
+      }
+    }
+
+    const results = await this.context.queries.searchVCons(searchFilters);
+
+    // Execute afterSearch hook (can filter results)
+    if (!options.skipHooks) {
+      const modifiedResults = await this.context.pluginManager.executeHook<VCon[]>(
+        'afterSearch', results, requestContext
+      );
+      if (modifiedResults) {
+        return modifiedResults;
+      }
+    }
+
+    return results;
+  }
+
+  // ========== Private Helpers ==========
+
+  /**
+   * Normalize vCon data with defaults
+   */
+  private normalizeVCon(data: Partial<VCon>): VCon {
+    return {
+      vcon: data.vcon || '0.3.0',
+      uuid: data.uuid || randomUUID(),
+      created_at: data.created_at || new Date().toISOString(),
+      updated_at: data.updated_at,
+      subject: data.subject,
+      parties: data.parties || [],
+      dialog: data.dialog,
+      analysis: data.analysis,
+      attachments: data.attachments,
+      group: data.group,
+      extensions: data.extensions,
+      must_support: data.must_support,
+      redacted: data.redacted,
+      appended: data.appended,
+    };
+  }
+}
+
+// ============================================================================
+// Custom Errors
+// ============================================================================
+
+export class VConValidationError extends Error {
+  constructor(public errors: string[]) {
+    super(`Validation failed: ${errors.join('; ')}`);
+    this.name = 'VConValidationError';
+  }
+}
+
+export class VConNotFoundError extends Error {
+  constructor(uuid: string) {
+    super(`vCon with UUID ${uuid} not found`);
+    this.name = 'VConNotFoundError';
+  }
+}
+

--- a/src/tools/handlers/base.ts
+++ b/src/tools/handlers/base.ts
@@ -6,28 +6,21 @@
 
 import { randomUUID } from 'crypto';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
-import { VConQueries } from '../../db/queries.js';
-import { PluginManager } from '../../hooks/plugin-manager.js';
 import { RequestContext } from '../../hooks/plugin-interface.js';
-import { DatabaseInspector } from '../../db/database-inspector.js';
-import { DatabaseAnalytics } from '../../db/database-analytics.js';
-import { DatabaseSizeAnalyzer } from '../../db/database-size-analyzer.js';
+import type { ServerContext } from '../../server/setup.js';
 import { withSpan, recordCounter, recordHistogram, logWithContext, attachErrorToSpan } from '../../observability/instrumentation.js';
 import { ATTR_TOOL_NAME, ATTR_TOOL_SUCCESS } from '../../observability/attributes.js';
 import { createTextResponse, createSuccessResponse } from '../../utils/responses.js';
 import { extractErrorMessage, createMcpError } from '../../utils/errors.js';
 
 /**
- * Context passed to all tool handlers containing dependencies
+ * Context passed to tool handlers - subset of ServerContext
+ * Excludes server/redis/handlerRegistry which handlers don't need
  */
-export interface ToolHandlerContext {
-  queries: VConQueries;
-  pluginManager: PluginManager;
-  dbInspector: DatabaseInspector;
-  dbAnalytics: DatabaseAnalytics;
-  dbSizeAnalyzer: DatabaseSizeAnalyzer;
-  supabase: any;
-}
+export type ToolHandlerContext = Pick<
+  ServerContext,
+  'queries' | 'pluginManager' | 'dbInspector' | 'dbAnalytics' | 'dbSizeAnalyzer' | 'supabase' | 'vconService'
+>;
 
 /**
  * Tool response format

--- a/tests/services/vcon-service.test.ts
+++ b/tests/services/vcon-service.test.ts
@@ -1,0 +1,580 @@
+/**
+ * VConService Tests
+ * 
+ * Tests for the unified vCon lifecycle service including hooks, validation, and metrics
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { randomUUID } from 'crypto';
+import { VConService, VConValidationError } from '../../src/services/vcon-service.js';
+import { VCon } from '../../src/types/vcon.js';
+import { VConQueries } from '../../src/db/queries.js';
+import { PluginManager } from '../../src/hooks/plugin-manager.js';
+
+// Mock observability
+vi.mock('../../src/observability/instrumentation.js', () => ({
+  logWithContext: vi.fn(),
+  recordCounter: vi.fn(),
+}));
+
+vi.mock('../../src/observability/attributes.js', () => ({
+  ATTR_VCON_UUID: 'vcon.uuid',
+}));
+
+describe('VConService', () => {
+  let service: VConService;
+  let mockQueries: any;
+  let mockPluginManager: any;
+
+  beforeEach(() => {
+    mockQueries = {
+      createVCon: vi.fn(),
+      getVCon: vi.fn(),
+      deleteVCon: vi.fn(),
+      searchVCons: vi.fn(),
+    };
+
+    mockPluginManager = {
+      executeHook: vi.fn(),
+    };
+
+    service = new VConService({
+      queries: mockQueries as unknown as VConQueries,
+      pluginManager: mockPluginManager as unknown as PluginManager,
+    });
+  });
+
+  describe('create', () => {
+    it('should create a vCon with auto-generated UUID and timestamp', async () => {
+      const createdUuid = randomUUID();
+      mockQueries.createVCon.mockResolvedValue({ uuid: createdUuid, id: '1' });
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      const result = await service.create({
+        parties: [{ name: 'Test User' }],
+      });
+
+      expect(result.uuid).toBe(createdUuid);
+      expect(result.vcon.vcon).toBe('0.3.0');
+      expect(result.vcon.uuid).toBeDefined();
+      expect(result.vcon.created_at).toBeDefined();
+      expect(result.vcon.parties).toEqual([{ name: 'Test User' }]);
+    });
+
+    it('should call beforeCreate hook before saving', async () => {
+      const createdUuid = randomUUID();
+      mockQueries.createVCon.mockResolvedValue({ uuid: createdUuid, id: '1' });
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      await service.create({
+        parties: [{ name: 'Test User' }],
+      });
+
+      // Verify beforeCreate was called with the vCon and request context
+      expect(mockPluginManager.executeHook).toHaveBeenCalledWith(
+        'beforeCreate',
+        expect.objectContaining({
+          vcon: '0.3.0',
+          parties: [{ name: 'Test User' }],
+        }),
+        expect.objectContaining({
+          timestamp: expect.any(Date),
+        })
+      );
+    });
+
+    it('should call afterCreate hook after saving', async () => {
+      const createdUuid = randomUUID();
+      mockQueries.createVCon.mockResolvedValue({ uuid: createdUuid, id: '1' });
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      await service.create({
+        parties: [{ name: 'Test User' }],
+      });
+
+      // Verify afterCreate was called
+      expect(mockPluginManager.executeHook).toHaveBeenCalledWith(
+        'afterCreate',
+        expect.objectContaining({
+          vcon: '0.3.0',
+          parties: [{ name: 'Test User' }],
+        }),
+        expect.objectContaining({
+          timestamp: expect.any(Date),
+        })
+      );
+    });
+
+    it('should apply modifications from beforeCreate hook', async () => {
+      const createdUuid = randomUUID();
+      const modifiedVCon: VCon = {
+        vcon: '0.3.0',
+        uuid: createdUuid,
+        created_at: new Date().toISOString(),
+        subject: 'Modified by plugin',
+        parties: [{ name: 'Test User' }],
+      };
+
+      mockQueries.createVCon.mockResolvedValue({ uuid: createdUuid, id: '1' });
+      mockPluginManager.executeHook.mockImplementation((hook: string) => {
+        if (hook === 'beforeCreate') return Promise.resolve(modifiedVCon);
+        return Promise.resolve(undefined);
+      });
+
+      const result = await service.create({
+        parties: [{ name: 'Test User' }],
+      });
+
+      // The modified vCon should be saved
+      expect(mockQueries.createVCon).toHaveBeenCalledWith(modifiedVCon);
+      expect(result.vcon.subject).toBe('Modified by plugin');
+    });
+
+    it('should throw if beforeCreate hook throws', async () => {
+      mockPluginManager.executeHook.mockRejectedValue(new Error('Plugin blocked creation'));
+
+      await expect(service.create({
+        parties: [{ name: 'Test User' }],
+      })).rejects.toThrow('Plugin blocked creation');
+
+      // createVCon should not be called
+      expect(mockQueries.createVCon).not.toHaveBeenCalled();
+    });
+
+    it('should validate vCon before saving', async () => {
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      // Empty parties should fail validation
+      await expect(service.create({
+        parties: [],
+      })).rejects.toThrow(VConValidationError);
+
+      expect(mockQueries.createVCon).not.toHaveBeenCalled();
+    });
+
+    it('should skip hooks when skipHooks option is true', async () => {
+      const createdUuid = randomUUID();
+      mockQueries.createVCon.mockResolvedValue({ uuid: createdUuid, id: '1' });
+
+      await service.create(
+        { parties: [{ name: 'Test User' }] },
+        { skipHooks: true }
+      );
+
+      expect(mockPluginManager.executeHook).not.toHaveBeenCalled();
+    });
+
+    it('should skip validation when skipValidation option is true', async () => {
+      const createdUuid = randomUUID();
+      mockQueries.createVCon.mockResolvedValue({ uuid: createdUuid, id: '1' });
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      // Empty parties would normally fail, but skipValidation bypasses it
+      const result = await service.create(
+        { parties: [] },
+        { skipValidation: true }
+      );
+
+      expect(result.uuid).toBe(createdUuid);
+    });
+
+    it('should pass source to request context', async () => {
+      const createdUuid = randomUUID();
+      mockQueries.createVCon.mockResolvedValue({ uuid: createdUuid, id: '1' });
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      await service.create(
+        { parties: [{ name: 'Test User' }] },
+        { source: 'rest-api' }
+      );
+
+      expect(mockPluginManager.executeHook).toHaveBeenCalledWith(
+        'beforeCreate',
+        expect.any(Object),
+        expect.objectContaining({
+          purpose: 'rest-api',
+        })
+      );
+    });
+  });
+
+  describe('createBatch', () => {
+    it('should create multiple vCons', async () => {
+      mockQueries.createVCon
+        .mockResolvedValueOnce({ uuid: 'uuid-1', id: '1' })
+        .mockResolvedValueOnce({ uuid: 'uuid-2', id: '2' });
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      const result = await service.createBatch([
+        { parties: [{ name: 'User 1' }] },
+        { parties: [{ name: 'User 2' }] },
+      ]);
+
+      expect(result.total).toBe(2);
+      expect(result.created).toBe(2);
+      expect(result.failed).toBe(0);
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0].success).toBe(true);
+      expect(result.results[1].success).toBe(true);
+    });
+
+    it('should continue processing on individual failures', async () => {
+      mockQueries.createVCon
+        .mockRejectedValueOnce(new Error('DB error'))
+        .mockResolvedValueOnce({ uuid: 'uuid-2', id: '2' });
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      const result = await service.createBatch([
+        { parties: [{ name: 'User 1' }] },
+        { parties: [{ name: 'User 2' }] },
+      ]);
+
+      expect(result.total).toBe(2);
+      expect(result.created).toBe(1);
+      expect(result.failed).toBe(1);
+      expect(result.results[0].success).toBe(false);
+      expect(result.results[0].error).toContain('DB error');
+      expect(result.results[1].success).toBe(true);
+    });
+
+    it('should call hooks for each vCon in batch', async () => {
+      mockQueries.createVCon
+        .mockResolvedValueOnce({ uuid: 'uuid-1', id: '1' })
+        .mockResolvedValueOnce({ uuid: 'uuid-2', id: '2' });
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      await service.createBatch([
+        { parties: [{ name: 'User 1' }] },
+        { parties: [{ name: 'User 2' }] },
+      ]);
+
+      // beforeCreate and afterCreate should be called twice each
+      const beforeCreateCalls = mockPluginManager.executeHook.mock.calls
+        .filter((call: any[]) => call[0] === 'beforeCreate');
+      const afterCreateCalls = mockPluginManager.executeHook.mock.calls
+        .filter((call: any[]) => call[0] === 'afterCreate');
+
+      expect(beforeCreateCalls).toHaveLength(2);
+      expect(afterCreateCalls).toHaveLength(2);
+    });
+  });
+
+  describe('get', () => {
+    it('should retrieve a vCon by UUID', async () => {
+      const testVCon: VCon = {
+        vcon: '0.3.0',
+        uuid: randomUUID(),
+        created_at: new Date().toISOString(),
+        parties: [{ name: 'Test User' }],
+      };
+
+      mockQueries.getVCon.mockResolvedValue(testVCon);
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      const result = await service.get(testVCon.uuid!);
+
+      expect(result).toEqual(testVCon);
+      expect(mockQueries.getVCon).toHaveBeenCalledWith(testVCon.uuid);
+    });
+
+    it('should call beforeRead hook before fetching', async () => {
+      const uuid = randomUUID();
+      const testVCon: VCon = {
+        vcon: '0.3.0',
+        uuid,
+        created_at: new Date().toISOString(),
+        parties: [],
+      };
+
+      mockQueries.getVCon.mockResolvedValue(testVCon);
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      await service.get(uuid);
+
+      expect(mockPluginManager.executeHook).toHaveBeenCalledWith(
+        'beforeRead',
+        uuid,
+        expect.objectContaining({
+          timestamp: expect.any(Date),
+        })
+      );
+    });
+
+    it('should call afterRead hook after fetching', async () => {
+      const testVCon: VCon = {
+        vcon: '0.3.0',
+        uuid: randomUUID(),
+        created_at: new Date().toISOString(),
+        parties: [],
+      };
+
+      mockQueries.getVCon.mockResolvedValue(testVCon);
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      await service.get(testVCon.uuid!);
+
+      expect(mockPluginManager.executeHook).toHaveBeenCalledWith(
+        'afterRead',
+        testVCon,
+        expect.objectContaining({
+          timestamp: expect.any(Date),
+        })
+      );
+    });
+
+    it('should apply modifications from afterRead hook', async () => {
+      const testVCon: VCon = {
+        vcon: '0.3.0',
+        uuid: randomUUID(),
+        created_at: new Date().toISOString(),
+        parties: [{ name: 'Test User' }],
+      };
+      const filteredVCon = { ...testVCon, subject: 'Filtered by plugin' };
+
+      mockQueries.getVCon.mockResolvedValue(testVCon);
+      mockPluginManager.executeHook.mockImplementation((hook: string) => {
+        if (hook === 'afterRead') return Promise.resolve(filteredVCon);
+        return Promise.resolve(undefined);
+      });
+
+      const result = await service.get(testVCon.uuid!);
+
+      expect(result.subject).toBe('Filtered by plugin');
+    });
+
+    it('should throw if beforeRead hook throws (access blocked)', async () => {
+      const uuid = randomUUID();
+      mockPluginManager.executeHook.mockRejectedValue(new Error('Access denied'));
+
+      await expect(service.get(uuid)).rejects.toThrow('Access denied');
+
+      // getVCon should not be called
+      expect(mockQueries.getVCon).not.toHaveBeenCalled();
+    });
+
+    it('should skip hooks when skipHooks option is true', async () => {
+      const testVCon: VCon = {
+        vcon: '0.3.0',
+        uuid: randomUUID(),
+        created_at: new Date().toISOString(),
+        parties: [],
+      };
+
+      mockQueries.getVCon.mockResolvedValue(testVCon);
+
+      await service.get(testVCon.uuid!, { skipHooks: true });
+
+      expect(mockPluginManager.executeHook).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a vCon by UUID', async () => {
+      const uuid = randomUUID();
+      const testVCon: VCon = {
+        vcon: '0.3.0',
+        uuid,
+        created_at: new Date().toISOString(),
+        parties: [],
+      };
+
+      mockQueries.getVCon.mockResolvedValue(testVCon);
+      mockQueries.deleteVCon.mockResolvedValue(undefined);
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      const result = await service.delete(uuid);
+
+      expect(result).toBe(true);
+      expect(mockQueries.deleteVCon).toHaveBeenCalledWith(uuid);
+    });
+
+    it('should return false if vCon not found', async () => {
+      const uuid = randomUUID();
+      mockQueries.getVCon.mockRejectedValue(new Error('Not found'));
+
+      const result = await service.delete(uuid);
+
+      expect(result).toBe(false);
+      expect(mockQueries.deleteVCon).not.toHaveBeenCalled();
+    });
+
+    it('should call beforeDelete hook before deleting', async () => {
+      const uuid = randomUUID();
+      const testVCon: VCon = {
+        vcon: '0.3.0',
+        uuid,
+        created_at: new Date().toISOString(),
+        parties: [],
+      };
+
+      mockQueries.getVCon.mockResolvedValue(testVCon);
+      mockQueries.deleteVCon.mockResolvedValue(undefined);
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      await service.delete(uuid);
+
+      expect(mockPluginManager.executeHook).toHaveBeenCalledWith(
+        'beforeDelete',
+        uuid,
+        expect.objectContaining({
+          timestamp: expect.any(Date),
+        })
+      );
+    });
+
+    it('should call afterDelete hook after deleting', async () => {
+      const uuid = randomUUID();
+      const testVCon: VCon = {
+        vcon: '0.3.0',
+        uuid,
+        created_at: new Date().toISOString(),
+        parties: [],
+      };
+
+      mockQueries.getVCon.mockResolvedValue(testVCon);
+      mockQueries.deleteVCon.mockResolvedValue(undefined);
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      await service.delete(uuid);
+
+      expect(mockPluginManager.executeHook).toHaveBeenCalledWith(
+        'afterDelete',
+        uuid,
+        expect.objectContaining({
+          timestamp: expect.any(Date),
+        })
+      );
+    });
+
+    it('should throw if beforeDelete hook throws (deletion blocked)', async () => {
+      const uuid = randomUUID();
+      const testVCon: VCon = {
+        vcon: '0.3.0',
+        uuid,
+        created_at: new Date().toISOString(),
+        parties: [],
+      };
+
+      mockQueries.getVCon.mockResolvedValue(testVCon);
+      mockPluginManager.executeHook.mockRejectedValue(new Error('Deletion blocked'));
+
+      await expect(service.delete(uuid)).rejects.toThrow('Deletion blocked');
+
+      // deleteVCon should not be called
+      expect(mockQueries.deleteVCon).not.toHaveBeenCalled();
+    });
+
+    it('should skip hooks when skipHooks option is true', async () => {
+      const uuid = randomUUID();
+      const testVCon: VCon = {
+        vcon: '0.3.0',
+        uuid,
+        created_at: new Date().toISOString(),
+        parties: [],
+      };
+
+      mockQueries.getVCon.mockResolvedValue(testVCon);
+      mockQueries.deleteVCon.mockResolvedValue(undefined);
+
+      await service.delete(uuid, { skipHooks: true });
+
+      expect(mockPluginManager.executeHook).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('search', () => {
+    it('should search vCons with filters', async () => {
+      const testVCons: VCon[] = [
+        { vcon: '0.3.0', uuid: randomUUID(), created_at: new Date().toISOString(), parties: [] },
+        { vcon: '0.3.0', uuid: randomUUID(), created_at: new Date().toISOString(), parties: [] },
+      ];
+
+      mockQueries.searchVCons.mockResolvedValue(testVCons);
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      const result = await service.search({ subject: 'test' });
+
+      expect(result).toEqual(testVCons);
+      expect(mockQueries.searchVCons).toHaveBeenCalledWith({ subject: 'test' });
+    });
+
+    it('should call beforeSearch hook to modify criteria', async () => {
+      const testVCons: VCon[] = [];
+      mockQueries.searchVCons.mockResolvedValue(testVCons);
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      await service.search({ subject: 'test' });
+
+      expect(mockPluginManager.executeHook).toHaveBeenCalledWith(
+        'beforeSearch',
+        { subject: 'test' },
+        expect.objectContaining({
+          timestamp: expect.any(Date),
+        })
+      );
+    });
+
+    it('should apply modified criteria from beforeSearch hook', async () => {
+      const modifiedFilters = { subject: 'modified', limit: 5 };
+      mockQueries.searchVCons.mockResolvedValue([]);
+      mockPluginManager.executeHook.mockImplementation((hook: string) => {
+        if (hook === 'beforeSearch') return Promise.resolve(modifiedFilters);
+        return Promise.resolve(undefined);
+      });
+
+      await service.search({ subject: 'original' });
+
+      expect(mockQueries.searchVCons).toHaveBeenCalledWith(modifiedFilters);
+    });
+
+    it('should call afterSearch hook to filter results', async () => {
+      const testVCons: VCon[] = [
+        { vcon: '0.3.0', uuid: randomUUID(), created_at: new Date().toISOString(), parties: [] },
+      ];
+
+      mockQueries.searchVCons.mockResolvedValue(testVCons);
+      mockPluginManager.executeHook.mockResolvedValue(undefined);
+
+      await service.search({});
+
+      expect(mockPluginManager.executeHook).toHaveBeenCalledWith(
+        'afterSearch',
+        testVCons,
+        expect.objectContaining({
+          timestamp: expect.any(Date),
+        })
+      );
+    });
+
+    it('should apply filtered results from afterSearch hook', async () => {
+      const testVCons: VCon[] = [
+        { vcon: '0.3.0', uuid: 'uuid-1', created_at: new Date().toISOString(), parties: [] },
+        { vcon: '0.3.0', uuid: 'uuid-2', created_at: new Date().toISOString(), parties: [] },
+      ];
+      const filteredVCons = [testVCons[0]]; // Plugin filters out second result
+
+      mockQueries.searchVCons.mockResolvedValue(testVCons);
+      mockPluginManager.executeHook.mockImplementation((hook: string) => {
+        if (hook === 'afterSearch') return Promise.resolve(filteredVCons);
+        return Promise.resolve(undefined);
+      });
+
+      const result = await service.search({});
+
+      expect(result).toHaveLength(1);
+      expect(result[0].uuid).toBe('uuid-1');
+    });
+  });
+
+  describe('VConValidationError', () => {
+    it('should contain validation errors', () => {
+      const error = new VConValidationError(['Error 1', 'Error 2']);
+
+      expect(error.name).toBe('VConValidationError');
+      expect(error.errors).toEqual(['Error 1', 'Error 2']);
+      expect(error.message).toContain('Error 1');
+      expect(error.message).toContain('Error 2');
+    });
+  });
+});
+


### PR DESCRIPTION
- Added Koa middleware for authentication, error handling, and request logging.
- Integrated REST API endpoints for vCon CRUD operations, including create, retrieve, list, and delete functionalities.
- Updated package dependencies to include Koa and related middleware.
- Created scripts for seeding test data and running integration tests for the vCon service.
- Refactored existing service and handler code to utilize the new vConService for consistent lifecycle management across API and tool handlers.

This commit enhances the application's API capabilities and improves the overall structure for handling vCon operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a production-ready REST layer and centralizes vCon lifecycle logic.
> 
> - **New REST API (Koa):** `src/api/rest-router.ts` exposes `POST /vcons`, `POST /vcons/batch`, `GET /vcons`, `GET /vcons/:uuid`, `DELETE /vcons/:uuid`, and `GET /health`; middleware in `src/api/auth.ts` adds API-key auth, error handling, and request logging
> - **HTTP transport integration:** `src/transport/http.ts` routes REST paths to Koa; `src/index.ts` wires REST context and logs endpoints on startup
> - **Unified service layer:** `src/services/vcon-service.ts` (exported via `src/services/index.ts`) encapsulates create/get/search/delete with hooks, validation, and metrics; MCP tool handlers (`src/tools/handlers/vcon-crud.ts`) and server handlers (`src/server/handlers.ts`, `src/server/setup.ts`) refactored to use it
> - **DB query tweaks:** `src/db/queries.ts` sets `vcons.id = vcon.uuid` on insert and returns 404-like error on missing UUID; tenant test updated to insert `id = uuid`
> - **Tooling & tests:** new scripts `scripts/seed-test-vcons.ts`, `scripts/test-api-integration.ts`; expanded tests for handlers and service (`tests/services/vcon-service.test.ts`, updates to handlers tests)
> - **Deps:** add `koa`, `@koa/router`, `@koa/cors`, `koa-bodyparser` (+ types); minor bump to `mime-types`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2870ae8022cfb5ca22be800c254a186cbbe95e25. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->