### PR TITLE
Enhance tool categorization and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,66 @@ Analyze SQL query execution plans for performance optimization (limited support)
 Show a minimal example vCon as JSON
 ```
 
+## Tool Categories & Configuration
+
+Tools are organized into categories that can be enabled or disabled for different deployment scenarios. By default, all categories are enabled.
+
+### Categories
+
+| Category | Tools | Description |
+|----------|-------|-------------|
+| `read` | `get_vcon`, `search_vcons`, `search_vcons_content`, `search_vcons_semantic`, `search_vcons_hybrid`, `get_tags`, `search_by_tags`, `get_unique_tags` | All read operations |
+| `write` | `create_vcon`, `update_vcon`, `delete_vcon`, `add_analysis`, `add_dialog`, `add_attachment`, `create_vcon_from_template`, `manage_tag`, `remove_all_tags` | All mutating operations |
+| `schema` | `get_schema`, `get_examples` | Documentation helpers |
+| `analytics` | `get_database_analytics`, `get_monthly_growth_analytics`, `get_attachment_analytics`, `get_tag_analytics`, `get_content_analytics`, `get_database_health_metrics` | Business intelligence |
+| `infra` | `get_database_shape`, `get_database_stats`, `analyze_query`, `get_database_size_info`, `get_smart_search_limits` | Admin/debugging |
+
+### Configuration Options
+
+Configure via environment variables:
+
+```bash
+# Option 1: Use a preset profile
+MCP_TOOLS_PROFILE=readonly   # Options: full, readonly, user, admin, minimal
+
+# Option 2: Enable specific categories only
+MCP_ENABLED_CATEGORIES=read,write,schema
+
+# Option 3: Disable specific categories (starts with all enabled)
+MCP_DISABLED_CATEGORIES=analytics,infra
+
+# Option 4: Disable individual tools
+MCP_DISABLED_TOOLS=delete_vcon,analyze_query
+```
+
+### Deployment Profiles
+
+| Profile | Categories | Use Case |
+|---------|------------|----------|
+| `full` | All | Development, full access |
+| `readonly` | read, schema | Read-only deployments |
+| `user` | read, write, schema | End-user facing |
+| `admin` | read, analytics, infra, schema | Admin dashboards |
+| `minimal` | read, write | Basic CRUD only |
+
+### Example: Read-Only Deployment
+
+```json
+{
+  "mcpServers": {
+    "vcon": {
+      "command": "node",
+      "args": ["/path/to/vcon-mcp/dist/index.js"],
+      "env": {
+        "SUPABASE_URL": "your-project-url",
+        "SUPABASE_ANON_KEY": "your-anon-key",
+        "MCP_TOOLS_PROFILE": "readonly"
+      }
+    }
+  }
+}
+```
+
 ## Available MCP Resources
 
 The server exposes URI-based resources for direct reads:

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -4,7 +4,7 @@ Complete reference for all Model Context Protocol (MCP) tools provided by the vC
 
 ## Overview
 
-The vCon MCP Server provides 25+ tools organized into these categories:
+The vCon MCP Server provides 30 tools organized into these functional groups:
 
 - **[Core Operations](#core-operations)** - Create, read, update, delete vCons
 - **[Component Management](#component-management)** - Add dialog, analysis, attachments
@@ -14,6 +14,50 @@ The vCon MCP Server provides 25+ tools organized into these categories:
 - **[Database Analytics](#database-analytics)** - Comprehensive database analytics and insights
 - **[Database Size Tools](#database-size-tools)** - Smart limits and size awareness for large databases
 - **[Schema & Examples](#schema--examples)** - Get schemas and example vCons
+
+---
+
+## Tool Categories
+
+Tools are organized into **5 categories** that can be enabled or disabled for different deployment scenarios. By default, all categories are enabled.
+
+| Category | Tools | Description |
+|----------|-------|-------------|
+| `read` | `get_vcon`, `search_vcons`, `search_vcons_content`, `search_vcons_semantic`, `search_vcons_hybrid`, `get_tags`, `search_by_tags`, `get_unique_tags` | All read operations |
+| `write` | `create_vcon`, `update_vcon`, `delete_vcon`, `add_analysis`, `add_dialog`, `add_attachment`, `create_vcon_from_template`, `manage_tag`, `remove_all_tags` | All mutating operations |
+| `schema` | `get_schema`, `get_examples` | Documentation helpers |
+| `analytics` | `get_database_analytics`, `get_monthly_growth_analytics`, `get_attachment_analytics`, `get_tag_analytics`, `get_content_analytics`, `get_database_health_metrics` | Business intelligence |
+| `infra` | `get_database_shape`, `get_database_stats`, `analyze_query`, `get_database_size_info`, `get_smart_search_limits` | Admin/debugging |
+
+### Enabling/Disabling Categories
+
+Configure via environment variables:
+
+```bash
+# Use a preset profile
+MCP_TOOLS_PROFILE=readonly   # Options: full, readonly, user, admin, minimal
+
+# Or enable specific categories only
+MCP_ENABLED_CATEGORIES=read,write,schema
+
+# Or disable specific categories (starts with all enabled)
+MCP_DISABLED_CATEGORIES=analytics,infra
+
+# Disable individual tools
+MCP_DISABLED_TOOLS=delete_vcon,analyze_query
+```
+
+### Deployment Profiles
+
+| Profile | Categories | Use Case |
+|---------|------------|----------|
+| `full` | All | Development, full access |
+| `readonly` | read, schema | Read-only deployments |
+| `user` | read, write, schema | End-user facing |
+| `admin` | read, analytics, infra, schema | Admin dashboards |
+| `minimal` | read, write | Basic CRUD only |
+
+See the [Configuration Guide](../guide/configuration.md) for more details.
 
 ---
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -111,6 +111,62 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-key
 VCON_PLUGINS_PATH=./plugins
 VCON_LICENSE_KEY=your-license-key
 NODE_ENV=production
+
+# Tool Categories (see below)
+MCP_TOOLS_PROFILE=full
+```
+
+## Tool Categories for Deployment
+
+Control which tools are available based on deployment type:
+
+### Deployment Profiles
+
+| Profile | Categories | Use Case |
+|---------|------------|----------|
+| `full` | All | Development, full access |
+| `readonly` | read, schema | Read-only API, dashboards |
+| `user` | read, write, schema | End-user facing applications |
+| `admin` | read, analytics, infra, schema | Admin/monitoring dashboards |
+| `minimal` | read, write | Basic CRUD microservice |
+
+### Configuration Options
+
+```bash
+# Option 1: Use a preset profile
+MCP_TOOLS_PROFILE=readonly
+
+# Option 2: Enable specific categories
+MCP_ENABLED_CATEGORIES=read,write,schema
+
+# Option 3: Disable specific categories
+MCP_DISABLED_CATEGORIES=analytics,infra
+
+# Option 4: Disable individual tools
+MCP_DISABLED_TOOLS=delete_vcon,analyze_query
+```
+
+### Example: Read-Only Deployment
+
+```bash
+# Docker run with read-only profile
+docker run -d \
+  -e SUPABASE_URL=your-url \
+  -e SUPABASE_ANON_KEY=your-key \
+  -e MCP_TOOLS_PROFILE=readonly \
+  vcon-mcp
+```
+
+### Example: User-Facing with Restricted Delete
+
+```bash
+# Allow CRUD but prevent deletion
+docker run -d \
+  -e SUPABASE_URL=your-url \
+  -e SUPABASE_ANON_KEY=your-key \
+  -e MCP_TOOLS_PROFILE=user \
+  -e MCP_DISABLED_TOOLS=delete_vcon \
+  vcon-mcp
 ```
 
 ## Health Checks

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -128,6 +128,44 @@ CURRENT_TENANT_ID=1124
 
 See [RLS Multi-Tenant Guide](rls-multi-tenant.md) for complete setup instructions.
 
+#### Tool Categories
+
+Control which tools are available in your deployment:
+
+```bash
+# Option 1: Use a preset profile
+MCP_TOOLS_PROFILE=readonly   # Options: full, readonly, user, admin, minimal
+
+# Option 2: Enable specific categories only
+MCP_ENABLED_CATEGORIES=read,write,schema
+
+# Option 3: Disable specific categories (starts with all enabled)
+MCP_DISABLED_CATEGORIES=analytics,infra
+
+# Option 4: Disable individual tools
+MCP_DISABLED_TOOLS=delete_vcon,analyze_query
+```
+
+**Available Categories:**
+
+| Category | Description |
+|----------|-------------|
+| `read` | Read operations: get_vcon, search_*, get_tags, search_by_tags, get_unique_tags |
+| `write` | Mutating operations: create_vcon, update_vcon, delete_vcon, add_*, manage_tag, remove_all_tags |
+| `schema` | Documentation: get_schema, get_examples |
+| `analytics` | Business intelligence: get_database_analytics, get_*_analytics |
+| `infra` | Admin/debugging: get_database_shape, get_database_stats, analyze_query, get_*_size_* |
+
+**Deployment Profiles:**
+
+| Profile | Categories | Use Case |
+|---------|------------|----------|
+| `full` | All | Development, full access |
+| `readonly` | read, schema | Read-only deployments |
+| `user` | read, write, schema | End-user facing |
+| `admin` | read, analytics, infra, schema | Admin dashboards |
+| `minimal` | read, write | Basic CRUD only |
+
 #### Logging and Debugging
 
 ```bash

--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -1,0 +1,171 @@
+/**
+ * Tool Configuration and Categories
+ *
+ * Provides category-based control for enabling/disabling groups of tools.
+ * By default, all categories are enabled.
+ *
+ * Environment Variables:
+ * - MCP_TOOLS_PROFILE: Use a preset profile (full, readonly, user, admin, minimal)
+ * - MCP_ENABLED_CATEGORIES: Comma-separated list of categories to enable
+ * - MCP_DISABLED_CATEGORIES: Comma-separated list of categories to disable
+ * - MCP_DISABLED_TOOLS: Comma-separated list of individual tools to disable
+ */
+
+import { createLogger } from '../observability/logger.js';
+
+const logger = createLogger('tools-config');
+
+/**
+ * Tool categories for enabling/disabling groups of tools
+ */
+export type ToolCategory = 'read' | 'write' | 'schema' | 'analytics' | 'infra';
+
+/**
+ * All available categories
+ */
+export const ALL_CATEGORIES: ToolCategory[] = ['read', 'write', 'schema', 'analytics', 'infra'];
+
+/**
+ * Tool definition with category metadata
+ */
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: object;
+  category: ToolCategory;
+}
+
+/**
+ * Configuration for which tools/categories are enabled
+ */
+export interface ToolsConfig {
+  // Category-level control
+  enabledCategories: ToolCategory[];
+
+  // Individual tool overrides (optional)
+  disabledTools?: string[];
+}
+
+/**
+ * Default configuration - all categories enabled
+ */
+export const DEFAULT_TOOLS_CONFIG: ToolsConfig = {
+  enabledCategories: [...ALL_CATEGORIES],
+};
+
+/**
+ * Preset deployment profiles
+ */
+export const DEPLOYMENT_PROFILES: Record<string, ToolsConfig> = {
+  // Full access - all tools
+  full: {
+    enabledCategories: ['read', 'write', 'schema', 'analytics', 'infra'],
+  },
+
+  // Read-only - no mutations
+  readonly: {
+    enabledCategories: ['read', 'schema'],
+  },
+
+  // User-facing - CRUD but no infra/analytics
+  user: {
+    enabledCategories: ['read', 'write', 'schema'],
+  },
+
+  // Admin - monitoring and analytics
+  admin: {
+    enabledCategories: ['read', 'analytics', 'infra', 'schema'],
+  },
+
+  // Minimal - just basic CRUD
+  minimal: {
+    enabledCategories: ['read', 'write'],
+  },
+};
+
+/**
+ * Load tools configuration from environment variables
+ */
+export function loadToolsConfig(): ToolsConfig {
+  // Check for deployment profile first
+  const profile = process.env.MCP_TOOLS_PROFILE;
+  if (profile && DEPLOYMENT_PROFILES[profile]) {
+    logger.info({ profile }, 'Using tools profile');
+    const config = { ...DEPLOYMENT_PROFILES[profile] };
+
+    // Allow additional disabled tools even with profile
+    const disabledToolsEnv = process.env.MCP_DISABLED_TOOLS;
+    if (disabledToolsEnv) {
+      config.disabledTools = disabledToolsEnv.split(',').map((t) => t.trim());
+    }
+
+    return config;
+  }
+
+  // Check for explicit category configuration
+  const enabledCategoriesEnv = process.env.MCP_ENABLED_CATEGORIES;
+  const disabledCategoriesEnv = process.env.MCP_DISABLED_CATEGORIES;
+
+  let enabledCategories: ToolCategory[];
+
+  if (enabledCategoriesEnv) {
+    // Explicit list of enabled categories
+    enabledCategories = enabledCategoriesEnv
+      .split(',')
+      .map((c) => c.trim())
+      .filter((c) => ALL_CATEGORIES.includes(c as ToolCategory)) as ToolCategory[];
+    logger.info({ enabledCategories }, 'Using explicit enabled categories');
+  } else if (disabledCategoriesEnv) {
+    // Start with all, remove disabled
+    const disabledCategories = disabledCategoriesEnv
+      .split(',')
+      .map((c) => c.trim()) as ToolCategory[];
+    enabledCategories = ALL_CATEGORIES.filter((c) => !disabledCategories.includes(c));
+    logger.info({ disabledCategories, enabledCategories }, 'Using disabled categories');
+  } else {
+    // Default: all enabled
+    enabledCategories = [...ALL_CATEGORIES];
+  }
+
+  // Check for disabled tools
+  const disabledToolsEnv = process.env.MCP_DISABLED_TOOLS;
+  const disabledTools = disabledToolsEnv?.split(',').map((t) => t.trim());
+
+  if (disabledTools?.length) {
+    logger.info({ disabledTools }, 'Individual tools disabled');
+  }
+
+  return {
+    enabledCategories,
+    disabledTools,
+  };
+}
+
+/**
+ * Filter tools based on configuration
+ */
+export function filterEnabledTools<T extends { name: string; category: ToolCategory }>(
+  tools: T[],
+  config: ToolsConfig
+): T[] {
+  return tools.filter((tool) => {
+    // Check if tool is explicitly disabled
+    if (config.disabledTools?.includes(tool.name)) {
+      return false;
+    }
+
+    // Check if tool's category is enabled
+    return config.enabledCategories.includes(tool.category);
+  });
+}
+
+/**
+ * Remove category field from tools for MCP response
+ * (MCP protocol doesn't need the category field)
+ */
+export function stripCategories<T extends { category: ToolCategory }>(
+  tools: T[]
+): Omit<T, 'category'>[] {
+  return tools.map(({ category, ...rest }) => rest);
+}
+

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -15,6 +15,7 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import { randomUUID } from 'crypto';
+import { loadToolsConfig, filterEnabledTools, stripCategories, type ToolDefinition } from '../config/tools.js';
 import { logWithContext } from '../observability/instrumentation.js';
 import { RequestContext } from '../hooks/plugin-interface.js';
 import type { ToolHandlerContext } from '../tools/handlers/index.js';
@@ -48,6 +49,9 @@ export function registerHandlers(context: ServerContext): void {
     vconService: context.vconService,
   };
 
+  // Load tools configuration once at startup
+  const toolsConfig = loadToolsConfig();
+
   // List tools
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     const transportType = process.env.MCP_TRANSPORT || 'stdio';
@@ -58,34 +62,70 @@ export function registerHandlers(context: ServerContext): void {
       transport: transportType,
     });
 
-    const coreTools = allTools;
-    const pluginTools = await pluginManager.getAdditionalTools();
-    const extras = [createFromTemplateTool, getSchemaTool, getExamplesTool];
-
-    const tools = [
-      ...coreTools,
-      ...extras,
+    // Combine all tools with their categories
+    const allToolsWithCategories: ToolDefinition[] = [
+      ...allTools,
+      createFromTemplateTool,
+      getSchemaTool,
+      getExamplesTool,
       ...allDatabaseTools,
       ...allDatabaseAnalyticsTools,
       ...allDatabaseSizeTools,
       ...allTagTools,
+    ] as ToolDefinition[];
+
+    // Filter based on configuration
+    const enabledTools = filterEnabledTools(allToolsWithCategories, toolsConfig);
+
+    // Get plugin tools (plugins don't have categories, always included if available)
+    const pluginTools = await pluginManager.getAdditionalTools();
+
+    // Strip category field for MCP response (MCP doesn't need it)
+    const toolsForResponse = [
+      ...stripCategories(enabledTools),
       ...pluginTools,
     ];
 
     logWithContext('debug', 'MCP tools listed', {
       request_id: requestId,
       transport: transportType,
-      total_tools: tools.length,
-      core_tools: coreTools.length,
+      total_tools: toolsForResponse.length,
+      enabled_categories: toolsConfig.enabledCategories,
+      disabled_tools: toolsConfig.disabledTools || [],
+      all_tools_count: allToolsWithCategories.length,
+      filtered_tools_count: enabledTools.length,
       plugin_tools: pluginTools.length,
     });
 
-    return { tools };
+    return { tools: toolsForResponse };
   });
 
   // Call tool
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
+
+    // Check if tool is disabled by configuration
+    const allToolsWithCategories: ToolDefinition[] = [
+      ...allTools,
+      createFromTemplateTool,
+      getSchemaTool,
+      getExamplesTool,
+      ...allDatabaseTools,
+      ...allDatabaseAnalyticsTools,
+      ...allDatabaseSizeTools,
+      ...allTagTools,
+    ] as ToolDefinition[];
+
+    const toolDef = allToolsWithCategories.find(t => t.name === name);
+    if (toolDef) {
+      const enabledTools = filterEnabledTools([toolDef], toolsConfig);
+      if (enabledTools.length === 0) {
+        throw new McpError(
+          ErrorCode.MethodNotFound,
+          `Tool '${name}' is disabled. Category '${toolDef.category}' is not enabled in current configuration.`
+        );
+      }
+    }
 
     // Try to get handler from registry
     const handler = handlerRegistry.get(name);

--- a/src/tools/database-analytics.ts
+++ b/src/tools/database-analytics.ts
@@ -4,12 +4,15 @@
  * Comprehensive tools for analyzing database shape, size, growth, and content patterns
  */
 
+import type { ToolCategory } from '../config/tools.js';
+
 /**
  * Tool: Get Database Analytics
  * Returns comprehensive database analytics including size, growth, content distribution
  */
 export const getDatabaseAnalyticsTool = {
   name: 'get_database_analytics',
+  category: 'analytics' as ToolCategory,
   description: 'Get comprehensive database analytics including total size, monthly growth trends, ' +
     'content distribution, attachment statistics, tag usage patterns, and database health metrics. ' +
     'Provides a complete overview of the vCon database state and usage patterns.',
@@ -58,6 +61,7 @@ export const getDatabaseAnalyticsTool = {
  */
 export const getMonthlyGrowthTool = {
   name: 'get_monthly_growth_analytics',
+  category: 'analytics' as ToolCategory,
   description: 'Get detailed monthly growth analytics including vCon creation trends, ' +
     'size growth patterns, content volume changes, and growth projections. ' +
     'Useful for capacity planning and understanding usage patterns.',
@@ -92,6 +96,7 @@ export const getMonthlyGrowthTool = {
  */
 export const getAttachmentAnalyticsTool = {
   name: 'get_attachment_analytics',
+  category: 'analytics' as ToolCategory,
   description: 'Get comprehensive attachment analytics including file type distribution, ' +
     'size statistics, attachment frequency, and storage usage patterns. ' +
     'Helps understand what types of files are being stored and their impact on storage.',
@@ -130,6 +135,7 @@ export const getAttachmentAnalyticsTool = {
  */
 export const getTagAnalyticsTool = {
   name: 'get_tag_analytics',
+  category: 'analytics' as ToolCategory,
   description: 'Get comprehensive tag analytics including usage patterns, ' +
     'key-value distribution, tag frequency, and tagging trends over time. ' +
     'Helps understand how vCons are being categorized and organized.',
@@ -174,6 +180,7 @@ export const getTagAnalyticsTool = {
  */
 export const getContentAnalyticsTool = {
   name: 'get_content_analytics',
+  category: 'analytics' as ToolCategory,
   description: 'Get comprehensive content analytics including dialog types, ' +
     'analysis distribution, party patterns, and conversation characteristics. ' +
     'Provides insights into the types of conversations being stored.',
@@ -215,6 +222,7 @@ export const getContentAnalyticsTool = {
  */
 export const getDatabaseHealthTool = {
   name: 'get_database_health_metrics',
+  category: 'analytics' as ToolCategory,
   description: 'Get database health metrics including performance indicators, ' +
     'storage efficiency, index usage, query performance, and optimization recommendations. ' +
     'Helps identify potential issues and optimization opportunities.',

--- a/src/tools/database-size-tools.ts
+++ b/src/tools/database-size-tools.ts
@@ -4,12 +4,15 @@
  * Tools for understanding database size and providing smart defaults
  */
 
+import type { ToolCategory } from '../config/tools.js';
+
 /**
  * Tool: Get Database Size Info
  * Returns database size information and recommendations for query limits
  */
 export const getDatabaseSizeInfoTool = {
   name: 'get_database_size_info',
+  category: 'infra' as ToolCategory,
   description: 'Get database size information and smart recommendations for query limits. ' +
     'Use this before running large queries to understand the database scale and get appropriate limits.',
   inputSchema: {
@@ -30,6 +33,7 @@ export const getDatabaseSizeInfoTool = {
  */
 export const getSmartSearchLimitsTool = {
   name: 'get_smart_search_limits',
+  category: 'infra' as ToolCategory,
   description: 'Get smart search limits based on database size and query complexity. ' +
     'Helps prevent memory exhaustion by suggesting appropriate limits for different query types.',
   inputSchema: {

--- a/src/tools/database-tools.ts
+++ b/src/tools/database-tools.ts
@@ -4,12 +4,15 @@
  * Tools for debugging, performance monitoring, and database shape inspection
  */
 
+import type { ToolCategory } from '../config/tools.js';
+
 /**
  * Tool: Get Database Shape
  * Returns comprehensive information about the database structure
  */
 export const getDatabaseShapeTool = {
   name: 'get_database_shape',
+  category: 'infra' as ToolCategory,
   description: 'Get comprehensive database structure information including tables, indexes, sizes, and relationships. ' +
     'Useful for debugging, performance tuning, and understanding the database schema.',
   inputSchema: {
@@ -45,6 +48,7 @@ export const getDatabaseShapeTool = {
  */
 export const getDatabaseStatsTool = {
   name: 'get_database_stats',
+  category: 'infra' as ToolCategory,
   description: 'Get database performance and usage statistics including query performance, cache hit ratios, ' +
     'table access patterns, and index usage. Useful for performance monitoring and optimization.',
   inputSchema: {
@@ -79,6 +83,7 @@ export const getDatabaseStatsTool = {
  */
 export const analyzeQueryTool = {
   name: 'analyze_query',
+  category: 'infra' as ToolCategory,
   description: 'Analyze a SQL query to understand its execution plan and performance characteristics. ' +
     'Useful for optimizing slow queries and understanding index usage.',
   inputSchema: {

--- a/src/tools/schema-tools.ts
+++ b/src/tools/schema-tools.ts
@@ -1,5 +1,8 @@
+import type { ToolCategory } from '../config/tools.js';
+
 export const getSchemaTool = {
   name: 'get_schema',
+  category: 'schema' as ToolCategory,
   description: 'Get vCon schema definition in the requested format (json_schema or typescript).',
   inputSchema: {
     type: 'object' as const,
@@ -12,6 +15,7 @@ export const getSchemaTool = {
 
 export const getExamplesTool = {
   name: 'get_examples',
+  category: 'schema' as ToolCategory,
   description: 'Get example vCons (minimal, phone_call, chat, email, video, full_featured) as JSON or YAML.',
   inputSchema: {
     type: 'object' as const,

--- a/src/tools/tag-tools.ts
+++ b/src/tools/tag-tools.ts
@@ -11,11 +11,14 @@
  * Consolidated from 8 tools to 5 tools for simpler API.
  */
 
+import type { ToolCategory } from '../config/tools.js';
+
 /**
  * Tool: Manage Tag (replaces add_tag, update_tags, remove_tag)
  */
 export const manageTagTool = {
   name: 'manage_tag',
+  category: 'write' as ToolCategory,
   description: 'Add, update, or remove a single tag on a vCon. Tags are key-value pairs for categorization and filtering. ' +
     'Use action "set" to add/update a tag, or "remove" to delete it.',
   inputSchema: {
@@ -53,6 +56,7 @@ export const manageTagTool = {
  */
 export const getTagsTool = {
   name: 'get_tags',
+  category: 'read' as ToolCategory,
   description: 'Retrieve tags from a vCon. Provide a specific key to get one tag value, or omit key to get all tags as an object.',
   inputSchema: {
     type: 'object' as const,
@@ -86,6 +90,7 @@ export const getTagsTool = {
  */
 export const removeAllTagsTool = {
   name: 'remove_all_tags',
+  category: 'write' as ToolCategory,
   description: 'Remove all tags from a vCon.',
   inputSchema: {
     type: 'object' as const,
@@ -105,6 +110,7 @@ export const removeAllTagsTool = {
  */
 export const searchByTagsTool = {
   name: 'search_by_tags',
+  category: 'read' as ToolCategory,
   description: 'Search for vCons that have specific tag values. All specified tags must match (AND logic).',
   inputSchema: {
     type: 'object' as const,
@@ -143,6 +149,7 @@ export const searchByTagsTool = {
  */
 export const getUniqueTagsTool = {
   name: 'get_unique_tags',
+  category: 'read' as ToolCategory,
   description: 'Get a list of all unique tag keys and their possible values across all vCons. ' +
     'Useful for discovering available tags, building tag selection UIs, and analytics.',
   inputSchema: {

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from 'crypto';
+import type { ToolCategory } from '../config/tools.js';
 import { VCon } from '../types/vcon.js';
 
 export const createFromTemplateTool = {
   name: 'create_vcon_from_template',
+  category: 'write' as ToolCategory,
   description: 'Create a new vCon from a predefined template (phone_call, chat_conversation, email_thread, video_meeting, custom).',
   inputSchema: {
     type: 'object' as const,

--- a/src/tools/vcon-crud.ts
+++ b/src/tools/vcon-crud.ts
@@ -99,11 +99,14 @@ export const AttachmentSchema = z.object({
 // MCP Tool Definitions
 // ============================================================================
 
+import type { ToolCategory } from '../config/tools.js';
+
 /**
  * Tool: Create vCon
  */
 export const createVConTool = {
   name: 'create_vcon',
+  category: 'write' as ToolCategory,
   description: 'Create a new vCon compliant with IETF draft-ietf-vcon-vcon-core-00. ' +
     'A vCon (virtual conversation) captures conversation data including parties, dialog, analysis, and attachments.',
   inputSchema: {
@@ -148,6 +151,7 @@ export const createVConTool = {
  */
 export const getVConTool = {
   name: 'get_vcon',
+  category: 'read' as ToolCategory,
   description: 'Retrieve a complete vCon by its UUID. Returns the full vCon object with all parties, dialog, analysis, and attachments.',
   inputSchema: {
     type: 'object' as const,
@@ -167,6 +171,7 @@ export const getVConTool = {
  */
 export const searchVConsTool = {
   name: 'search_vcons',
+  category: 'read' as ToolCategory,
   description: 'Search for vCons using various criteria including tags. Returns an array of matching vCons. ' +
     'For full-text or semantic search of conversation content, use search_vcons_content instead. ' +
     '⚠️ LARGE DATABASE WARNING: Use response_format="metadata" for large result sets to avoid memory issues.',
@@ -230,6 +235,7 @@ export const searchVConsTool = {
  */
 export const searchVConsContentTool = {
   name: 'search_vcons_content',
+  category: 'read' as ToolCategory,
   description: 'Full-text keyword search across vCon content including subject, dialog, analysis, and party info. ' +
     'Searches through conversation text, analysis bodies, and participant details. Returns ranked results with snippets. ' +
     '⚠️ LARGE DATABASE WARNING: Use response_format="snippets" for large result sets to avoid memory issues.',
@@ -282,6 +288,7 @@ export const searchVConsContentTool = {
  */
 export const searchVConsSemanticTool = {
   name: 'search_vcons_semantic',
+  category: 'read' as ToolCategory,
   description: 'Semantic search using AI embeddings to find conversations by meaning, not just keywords. ' +
     'Searches through subject, dialog, and analysis content. Returns similar conversations based on semantic similarity. ' +
     'Note: Requires embeddings to be generated for vCons (see embedding documentation). ' +
@@ -338,6 +345,7 @@ export const searchVConsSemanticTool = {
  */
 export const searchVConsHybridTool = {
   name: 'search_vcons_hybrid',
+  category: 'read' as ToolCategory,
   description: 'Hybrid search combining keyword and semantic search for comprehensive results. ' +
     'Uses both full-text matching and AI embeddings to find relevant conversations. ' +
     'Ideal for complex queries where you want both exact matches and conceptually similar content. ' +
@@ -396,6 +404,7 @@ export const searchVConsHybridTool = {
  */
 export const addAnalysisTool = {
   name: 'add_analysis',
+  category: 'write' as ToolCategory,
   description: 'Add analysis to an existing vCon. Analysis represents AI/ML processing results like transcripts, summaries, or sentiment. ' +
     'IMPORTANT: vendor field is REQUIRED per IETF spec.',
   inputSchema: {
@@ -460,6 +469,7 @@ export const addAnalysisTool = {
  */
 export const addDialogTool = {
   name: 'add_dialog',
+  category: 'write' as ToolCategory,
   description: 'Add a dialog (conversation segment) to an existing vCon. Dialog can be a recording, text, transfer, or incomplete.',
   inputSchema: {
     type: 'object' as const,
@@ -529,6 +539,7 @@ export const addDialogTool = {
  */
 export const addAttachmentTool = {
   name: 'add_attachment',
+  category: 'write' as ToolCategory,
   description: 'Add an attachment to an existing vCon. Attachments can be files, documents, or other data related to the conversation.',
   inputSchema: {
     type: 'object' as const,
@@ -573,6 +584,7 @@ export const addAttachmentTool = {
  */
 export const deleteVConTool = {
   name: 'delete_vcon',
+  category: 'write' as ToolCategory,
   description: 'Delete a vCon and all its related data (parties, dialog, analysis, attachments). This operation cannot be undone.',
   inputSchema: {
     type: 'object' as const,
@@ -593,6 +605,7 @@ export const deleteVConTool = {
  */
 export const updateVConTool = {
   name: 'update_vcon',
+  category: 'write' as ToolCategory,
   description: 'Update top-level vCon metadata (subject, extensions, must_support). For dialog, analysis, attachments use their specific tools.',
   inputSchema: {
     type: 'object' as const,

--- a/tests/config/tools.test.ts
+++ b/tests/config/tools.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Tests for Tool Categories Configuration
+ *
+ * Verifies that tools can be enabled/disabled via:
+ * - Deployment profiles (full, readonly, user, admin, minimal)
+ * - Category-based configuration
+ * - Individual tool disabling
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  loadToolsConfig,
+  filterEnabledTools,
+  stripCategories,
+  ALL_CATEGORIES,
+  DEPLOYMENT_PROFILES,
+  DEFAULT_TOOLS_CONFIG,
+  type ToolCategory,
+  type ToolDefinition,
+} from '../../src/config/tools.js';
+
+// Sample tools for testing
+const sampleTools: ToolDefinition[] = [
+  { name: 'get_vcon', category: 'read', description: 'Get vCon', inputSchema: {} },
+  { name: 'search_vcons', category: 'read', description: 'Search vCons', inputSchema: {} },
+  { name: 'create_vcon', category: 'write', description: 'Create vCon', inputSchema: {} },
+  { name: 'delete_vcon', category: 'write', description: 'Delete vCon', inputSchema: {} },
+  { name: 'get_schema', category: 'schema', description: 'Get schema', inputSchema: {} },
+  { name: 'get_database_analytics', category: 'analytics', description: 'Get analytics', inputSchema: {} },
+  { name: 'get_database_shape', category: 'infra', description: 'Get DB shape', inputSchema: {} },
+];
+
+describe('Tool Categories Configuration', () => {
+  // Store original env vars
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    // Save original env vars
+    originalEnv.MCP_TOOLS_PROFILE = process.env.MCP_TOOLS_PROFILE;
+    originalEnv.MCP_ENABLED_CATEGORIES = process.env.MCP_ENABLED_CATEGORIES;
+    originalEnv.MCP_DISABLED_CATEGORIES = process.env.MCP_DISABLED_CATEGORIES;
+    originalEnv.MCP_DISABLED_TOOLS = process.env.MCP_DISABLED_TOOLS;
+
+    // Clear all env vars
+    delete process.env.MCP_TOOLS_PROFILE;
+    delete process.env.MCP_ENABLED_CATEGORIES;
+    delete process.env.MCP_DISABLED_CATEGORIES;
+    delete process.env.MCP_DISABLED_TOOLS;
+  });
+
+  afterEach(() => {
+    // Restore original env vars
+    if (originalEnv.MCP_TOOLS_PROFILE !== undefined) {
+      process.env.MCP_TOOLS_PROFILE = originalEnv.MCP_TOOLS_PROFILE;
+    } else {
+      delete process.env.MCP_TOOLS_PROFILE;
+    }
+    if (originalEnv.MCP_ENABLED_CATEGORIES !== undefined) {
+      process.env.MCP_ENABLED_CATEGORIES = originalEnv.MCP_ENABLED_CATEGORIES;
+    } else {
+      delete process.env.MCP_ENABLED_CATEGORIES;
+    }
+    if (originalEnv.MCP_DISABLED_CATEGORIES !== undefined) {
+      process.env.MCP_DISABLED_CATEGORIES = originalEnv.MCP_DISABLED_CATEGORIES;
+    } else {
+      delete process.env.MCP_DISABLED_CATEGORIES;
+    }
+    if (originalEnv.MCP_DISABLED_TOOLS !== undefined) {
+      process.env.MCP_DISABLED_TOOLS = originalEnv.MCP_DISABLED_TOOLS;
+    } else {
+      delete process.env.MCP_DISABLED_TOOLS;
+    }
+  });
+
+  describe('Constants', () => {
+    it('should have all 5 categories defined', () => {
+      expect(ALL_CATEGORIES).toEqual(['read', 'write', 'schema', 'analytics', 'infra']);
+    });
+
+    it('should have default config with all categories enabled', () => {
+      expect(DEFAULT_TOOLS_CONFIG.enabledCategories).toEqual(ALL_CATEGORIES);
+      expect(DEFAULT_TOOLS_CONFIG.disabledTools).toBeUndefined();
+    });
+
+    it('should have all deployment profiles defined', () => {
+      expect(Object.keys(DEPLOYMENT_PROFILES)).toEqual(['full', 'readonly', 'user', 'admin', 'minimal']);
+    });
+  });
+
+  describe('Deployment Profiles', () => {
+    it('full profile should enable all categories', () => {
+      expect(DEPLOYMENT_PROFILES.full.enabledCategories).toEqual(['read', 'write', 'schema', 'analytics', 'infra']);
+    });
+
+    it('readonly profile should only enable read and schema', () => {
+      expect(DEPLOYMENT_PROFILES.readonly.enabledCategories).toEqual(['read', 'schema']);
+    });
+
+    it('user profile should enable read, write, and schema', () => {
+      expect(DEPLOYMENT_PROFILES.user.enabledCategories).toEqual(['read', 'write', 'schema']);
+    });
+
+    it('admin profile should enable read, analytics, infra, and schema', () => {
+      expect(DEPLOYMENT_PROFILES.admin.enabledCategories).toEqual(['read', 'analytics', 'infra', 'schema']);
+    });
+
+    it('minimal profile should only enable read and write', () => {
+      expect(DEPLOYMENT_PROFILES.minimal.enabledCategories).toEqual(['read', 'write']);
+    });
+  });
+
+  describe('loadToolsConfig', () => {
+    it('should return default config when no env vars set', () => {
+      const config = loadToolsConfig();
+      expect(config.enabledCategories).toEqual(ALL_CATEGORIES);
+      expect(config.disabledTools).toBeUndefined();
+    });
+
+    it('should load profile from MCP_TOOLS_PROFILE', () => {
+      process.env.MCP_TOOLS_PROFILE = 'readonly';
+      const config = loadToolsConfig();
+      expect(config.enabledCategories).toEqual(['read', 'schema']);
+    });
+
+    it('should load user profile from MCP_TOOLS_PROFILE', () => {
+      process.env.MCP_TOOLS_PROFILE = 'user';
+      const config = loadToolsConfig();
+      expect(config.enabledCategories).toEqual(['read', 'write', 'schema']);
+    });
+
+    it('should load admin profile from MCP_TOOLS_PROFILE', () => {
+      process.env.MCP_TOOLS_PROFILE = 'admin';
+      const config = loadToolsConfig();
+      expect(config.enabledCategories).toEqual(['read', 'analytics', 'infra', 'schema']);
+    });
+
+    it('should load minimal profile from MCP_TOOLS_PROFILE', () => {
+      process.env.MCP_TOOLS_PROFILE = 'minimal';
+      const config = loadToolsConfig();
+      expect(config.enabledCategories).toEqual(['read', 'write']);
+    });
+
+    it('should ignore invalid profile and use default', () => {
+      process.env.MCP_TOOLS_PROFILE = 'invalid_profile';
+      const config = loadToolsConfig();
+      expect(config.enabledCategories).toEqual(ALL_CATEGORIES);
+    });
+
+    it('should parse MCP_ENABLED_CATEGORIES', () => {
+      process.env.MCP_ENABLED_CATEGORIES = 'read,write';
+      const config = loadToolsConfig();
+      expect(config.enabledCategories).toEqual(['read', 'write']);
+    });
+
+    it('should handle whitespace in MCP_ENABLED_CATEGORIES', () => {
+      process.env.MCP_ENABLED_CATEGORIES = ' read , write , schema ';
+      const config = loadToolsConfig();
+      expect(config.enabledCategories).toEqual(['read', 'write', 'schema']);
+    });
+
+    it('should filter invalid categories from MCP_ENABLED_CATEGORIES', () => {
+      process.env.MCP_ENABLED_CATEGORIES = 'read,invalid,write';
+      const config = loadToolsConfig();
+      expect(config.enabledCategories).toEqual(['read', 'write']);
+    });
+
+    it('should parse MCP_DISABLED_CATEGORIES', () => {
+      process.env.MCP_DISABLED_CATEGORIES = 'analytics,infra';
+      const config = loadToolsConfig();
+      expect(config.enabledCategories).toEqual(['read', 'write', 'schema']);
+    });
+
+    it('should prioritize MCP_ENABLED_CATEGORIES over MCP_DISABLED_CATEGORIES', () => {
+      process.env.MCP_ENABLED_CATEGORIES = 'read';
+      process.env.MCP_DISABLED_CATEGORIES = 'write';
+      const config = loadToolsConfig();
+      // MCP_ENABLED_CATEGORIES takes precedence
+      expect(config.enabledCategories).toEqual(['read']);
+    });
+
+    it('should parse MCP_DISABLED_TOOLS', () => {
+      process.env.MCP_DISABLED_TOOLS = 'delete_vcon,analyze_query';
+      const config = loadToolsConfig();
+      expect(config.disabledTools).toEqual(['delete_vcon', 'analyze_query']);
+    });
+
+    it('should combine profile with disabled tools', () => {
+      process.env.MCP_TOOLS_PROFILE = 'user';
+      process.env.MCP_DISABLED_TOOLS = 'delete_vcon';
+      const config = loadToolsConfig();
+      expect(config.enabledCategories).toEqual(['read', 'write', 'schema']);
+      expect(config.disabledTools).toEqual(['delete_vcon']);
+    });
+
+    it('should prioritize profile over category env vars', () => {
+      process.env.MCP_TOOLS_PROFILE = 'readonly';
+      process.env.MCP_ENABLED_CATEGORIES = 'read,write,schema';
+      const config = loadToolsConfig();
+      // Profile takes precedence
+      expect(config.enabledCategories).toEqual(['read', 'schema']);
+    });
+  });
+
+  describe('filterEnabledTools', () => {
+    it('should return all tools when all categories enabled', () => {
+      const config = { enabledCategories: ALL_CATEGORIES as ToolCategory[] };
+      const filtered = filterEnabledTools(sampleTools, config);
+      expect(filtered).toHaveLength(sampleTools.length);
+      expect(filtered.map((t) => t.name)).toEqual(sampleTools.map((t) => t.name));
+    });
+
+    it('should filter tools by category', () => {
+      const config = { enabledCategories: ['read'] as ToolCategory[] };
+      const filtered = filterEnabledTools(sampleTools, config);
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map((t) => t.name)).toEqual(['get_vcon', 'search_vcons']);
+    });
+
+    it('should filter tools for readonly profile', () => {
+      const config = { enabledCategories: ['read', 'schema'] as ToolCategory[] };
+      const filtered = filterEnabledTools(sampleTools, config);
+      expect(filtered).toHaveLength(3);
+      expect(filtered.map((t) => t.name)).toEqual(['get_vcon', 'search_vcons', 'get_schema']);
+    });
+
+    it('should filter tools for user profile', () => {
+      const config = { enabledCategories: ['read', 'write', 'schema'] as ToolCategory[] };
+      const filtered = filterEnabledTools(sampleTools, config);
+      expect(filtered).toHaveLength(5);
+      expect(filtered.map((t) => t.name)).toEqual([
+        'get_vcon',
+        'search_vcons',
+        'create_vcon',
+        'delete_vcon',
+        'get_schema',
+      ]);
+    });
+
+    it('should filter tools for admin profile', () => {
+      const config = { enabledCategories: ['read', 'analytics', 'infra', 'schema'] as ToolCategory[] };
+      const filtered = filterEnabledTools(sampleTools, config);
+      expect(filtered).toHaveLength(5);
+      expect(filtered.map((t) => t.name)).toEqual([
+        'get_vcon',
+        'search_vcons',
+        'get_schema',
+        'get_database_analytics',
+        'get_database_shape',
+      ]);
+    });
+
+    it('should exclude individually disabled tools', () => {
+      const config = {
+        enabledCategories: ALL_CATEGORIES as ToolCategory[],
+        disabledTools: ['delete_vcon'],
+      };
+      const filtered = filterEnabledTools(sampleTools, config);
+      expect(filtered).toHaveLength(6);
+      expect(filtered.map((t) => t.name)).not.toContain('delete_vcon');
+    });
+
+    it('should exclude multiple disabled tools', () => {
+      const config = {
+        enabledCategories: ALL_CATEGORIES as ToolCategory[],
+        disabledTools: ['delete_vcon', 'get_database_shape'],
+      };
+      const filtered = filterEnabledTools(sampleTools, config);
+      expect(filtered).toHaveLength(5);
+      expect(filtered.map((t) => t.name)).not.toContain('delete_vcon');
+      expect(filtered.map((t) => t.name)).not.toContain('get_database_shape');
+    });
+
+    it('should combine category filtering with tool disabling', () => {
+      const config = {
+        enabledCategories: ['read', 'write'] as ToolCategory[],
+        disabledTools: ['delete_vcon'],
+      };
+      const filtered = filterEnabledTools(sampleTools, config);
+      expect(filtered).toHaveLength(3);
+      expect(filtered.map((t) => t.name)).toEqual(['get_vcon', 'search_vcons', 'create_vcon']);
+    });
+
+    it('should return empty array when no categories enabled', () => {
+      const config = { enabledCategories: [] as ToolCategory[] };
+      const filtered = filterEnabledTools(sampleTools, config);
+      expect(filtered).toHaveLength(0);
+    });
+
+    it('should handle empty tools array', () => {
+      const config = { enabledCategories: ALL_CATEGORIES as ToolCategory[] };
+      const filtered = filterEnabledTools([], config);
+      expect(filtered).toHaveLength(0);
+    });
+  });
+
+  describe('stripCategories', () => {
+    it('should remove category field from tools', () => {
+      const stripped = stripCategories(sampleTools);
+      expect(stripped).toHaveLength(sampleTools.length);
+      stripped.forEach((tool) => {
+        expect(tool).not.toHaveProperty('category');
+        expect(tool).toHaveProperty('name');
+        expect(tool).toHaveProperty('description');
+        expect(tool).toHaveProperty('inputSchema');
+      });
+    });
+
+    it('should preserve all other fields', () => {
+      const stripped = stripCategories(sampleTools);
+      expect(stripped[0]).toEqual({
+        name: 'get_vcon',
+        description: 'Get vCon',
+        inputSchema: {},
+      });
+    });
+
+    it('should handle empty array', () => {
+      const stripped = stripCategories([]);
+      expect(stripped).toHaveLength(0);
+    });
+  });
+
+  describe('Integration: Profile-based filtering', () => {
+    it('readonly profile should only return read and schema tools', () => {
+      process.env.MCP_TOOLS_PROFILE = 'readonly';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(sampleTools, config);
+
+      expect(filtered.map((t) => t.name)).toEqual(['get_vcon', 'search_vcons', 'get_schema']);
+    });
+
+    it('user profile should exclude analytics and infra tools', () => {
+      process.env.MCP_TOOLS_PROFILE = 'user';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(sampleTools, config);
+
+      expect(filtered.map((t) => t.name)).toEqual([
+        'get_vcon',
+        'search_vcons',
+        'create_vcon',
+        'delete_vcon',
+        'get_schema',
+      ]);
+      expect(filtered.map((t) => t.name)).not.toContain('get_database_analytics');
+      expect(filtered.map((t) => t.name)).not.toContain('get_database_shape');
+    });
+
+    it('admin profile should exclude write tools', () => {
+      process.env.MCP_TOOLS_PROFILE = 'admin';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(sampleTools, config);
+
+      expect(filtered.map((t) => t.name)).not.toContain('create_vcon');
+      expect(filtered.map((t) => t.name)).not.toContain('delete_vcon');
+    });
+
+    it('minimal profile should only return read and write tools', () => {
+      process.env.MCP_TOOLS_PROFILE = 'minimal';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(sampleTools, config);
+
+      expect(filtered.map((t) => t.name)).toEqual([
+        'get_vcon',
+        'search_vcons',
+        'create_vcon',
+        'delete_vcon',
+      ]);
+    });
+
+    it('user profile with disabled delete should exclude delete_vcon', () => {
+      process.env.MCP_TOOLS_PROFILE = 'user';
+      process.env.MCP_DISABLED_TOOLS = 'delete_vcon';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(sampleTools, config);
+
+      expect(filtered.map((t) => t.name)).toEqual([
+        'get_vcon',
+        'search_vcons',
+        'create_vcon',
+        'get_schema',
+      ]);
+    });
+  });
+});
+

--- a/tests/handlers/tool-categories.test.ts
+++ b/tests/handlers/tool-categories.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Integration Tests for Tool Categories in Handlers
+ *
+ * Verifies that:
+ * - Only enabled tools are listed
+ * - Disabled tools cannot be called
+ * - Error messages are helpful
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  loadToolsConfig,
+  filterEnabledTools,
+  type ToolDefinition,
+} from '../../src/config/tools.js';
+
+// Import actual tools to test with real data
+import { allTools } from '../../src/tools/vcon-crud.js';
+import { allTagTools } from '../../src/tools/tag-tools.js';
+import { allDatabaseTools } from '../../src/tools/database-tools.js';
+import { allDatabaseAnalyticsTools } from '../../src/tools/database-analytics.js';
+import { allDatabaseSizeTools } from '../../src/tools/database-size-tools.js';
+import { getSchemaTool, getExamplesTool } from '../../src/tools/schema-tools.js';
+import { createFromTemplateTool } from '../../src/tools/templates.js';
+
+describe('Tool Categories Integration', () => {
+  // Store original env vars
+  const originalEnv: Record<string, string | undefined> = {};
+
+  // Combine all tools like the handler does
+  const allToolsWithCategories: ToolDefinition[] = [
+    ...allTools,
+    createFromTemplateTool,
+    getSchemaTool,
+    getExamplesTool,
+    ...allDatabaseTools,
+    ...allDatabaseAnalyticsTools,
+    ...allDatabaseSizeTools,
+    ...allTagTools,
+  ] as ToolDefinition[];
+
+  beforeEach(() => {
+    // Save original env vars
+    originalEnv.MCP_TOOLS_PROFILE = process.env.MCP_TOOLS_PROFILE;
+    originalEnv.MCP_ENABLED_CATEGORIES = process.env.MCP_ENABLED_CATEGORIES;
+    originalEnv.MCP_DISABLED_CATEGORIES = process.env.MCP_DISABLED_CATEGORIES;
+    originalEnv.MCP_DISABLED_TOOLS = process.env.MCP_DISABLED_TOOLS;
+
+    // Clear all env vars
+    delete process.env.MCP_TOOLS_PROFILE;
+    delete process.env.MCP_ENABLED_CATEGORIES;
+    delete process.env.MCP_DISABLED_CATEGORIES;
+    delete process.env.MCP_DISABLED_TOOLS;
+  });
+
+  afterEach(() => {
+    // Restore original env vars
+    Object.entries(originalEnv).forEach(([key, value]) => {
+      if (value !== undefined) {
+        process.env[key] = value;
+      } else {
+        delete process.env[key];
+      }
+    });
+  });
+
+  describe('All tools have categories', () => {
+    it('should have category defined for all core tools', () => {
+      allTools.forEach((tool: any) => {
+        expect(tool.category, `Tool ${tool.name} should have category`).toBeDefined();
+        expect(['read', 'write', 'schema', 'analytics', 'infra']).toContain(tool.category);
+      });
+    });
+
+    it('should have category defined for all tag tools', () => {
+      allTagTools.forEach((tool: any) => {
+        expect(tool.category, `Tool ${tool.name} should have category`).toBeDefined();
+        expect(['read', 'write']).toContain(tool.category);
+      });
+    });
+
+    it('should have category defined for all database tools', () => {
+      allDatabaseTools.forEach((tool: any) => {
+        expect(tool.category, `Tool ${tool.name} should have category`).toBeDefined();
+        expect(tool.category).toBe('infra');
+      });
+    });
+
+    it('should have category defined for all analytics tools', () => {
+      allDatabaseAnalyticsTools.forEach((tool: any) => {
+        expect(tool.category, `Tool ${tool.name} should have category`).toBeDefined();
+        expect(tool.category).toBe('analytics');
+      });
+    });
+
+    it('should have category defined for schema tools', () => {
+      expect((getSchemaTool as any).category).toBe('schema');
+      expect((getExamplesTool as any).category).toBe('schema');
+    });
+
+    it('should have category defined for template tool', () => {
+      expect((createFromTemplateTool as any).category).toBe('write');
+    });
+  });
+
+  describe('Tool count by category', () => {
+    it('should have expected number of read tools', () => {
+      const readTools = allToolsWithCategories.filter((t) => t.category === 'read');
+      // get_vcon, search_vcons, search_vcons_content, search_vcons_semantic, search_vcons_hybrid
+      // get_tags, search_by_tags, get_unique_tags
+      expect(readTools.length).toBe(8);
+    });
+
+    it('should have expected number of write tools', () => {
+      const writeTools = allToolsWithCategories.filter((t) => t.category === 'write');
+      // create_vcon, update_vcon, delete_vcon, add_analysis, add_dialog, add_attachment
+      // create_vcon_from_template, manage_tag, remove_all_tags
+      expect(writeTools.length).toBe(9);
+    });
+
+    it('should have expected number of schema tools', () => {
+      const schemaTools = allToolsWithCategories.filter((t) => t.category === 'schema');
+      // get_schema, get_examples
+      expect(schemaTools.length).toBe(2);
+    });
+
+    it('should have expected number of analytics tools', () => {
+      const analyticsTools = allToolsWithCategories.filter((t) => t.category === 'analytics');
+      // 6 analytics tools
+      expect(analyticsTools.length).toBe(6);
+    });
+
+    it('should have expected number of infra tools', () => {
+      const infraTools = allToolsWithCategories.filter((t) => t.category === 'infra');
+      // get_database_shape, get_database_stats, analyze_query
+      // get_database_size_info, get_smart_search_limits
+      expect(infraTools.length).toBe(5);
+    });
+
+    it('should have 30 total tools', () => {
+      expect(allToolsWithCategories.length).toBe(30);
+    });
+  });
+
+  describe('Filtering with profiles', () => {
+    it('full profile should return all 30 tools', () => {
+      process.env.MCP_TOOLS_PROFILE = 'full';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(allToolsWithCategories, config);
+      expect(filtered.length).toBe(30);
+    });
+
+    it('readonly profile should return only read and schema tools (10 total)', () => {
+      process.env.MCP_TOOLS_PROFILE = 'readonly';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(allToolsWithCategories, config);
+      expect(filtered.length).toBe(10); // 8 read + 2 schema
+
+      // Verify specific tools
+      const toolNames = filtered.map((t) => t.name);
+      expect(toolNames).toContain('get_vcon');
+      expect(toolNames).toContain('search_vcons');
+      expect(toolNames).toContain('get_schema');
+      expect(toolNames).not.toContain('create_vcon');
+      expect(toolNames).not.toContain('delete_vcon');
+    });
+
+    it('user profile should return read, write, and schema tools (19 total)', () => {
+      process.env.MCP_TOOLS_PROFILE = 'user';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(allToolsWithCategories, config);
+      expect(filtered.length).toBe(19); // 8 read + 9 write + 2 schema
+
+      // Verify specific tools
+      const toolNames = filtered.map((t) => t.name);
+      expect(toolNames).toContain('get_vcon');
+      expect(toolNames).toContain('create_vcon');
+      expect(toolNames).toContain('delete_vcon');
+      expect(toolNames).not.toContain('get_database_analytics');
+      expect(toolNames).not.toContain('get_database_shape');
+    });
+
+    it('admin profile should return read, analytics, infra, and schema tools (21 total)', () => {
+      process.env.MCP_TOOLS_PROFILE = 'admin';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(allToolsWithCategories, config);
+      expect(filtered.length).toBe(21); // 8 read + 6 analytics + 5 infra + 2 schema
+
+      // Verify specific tools
+      const toolNames = filtered.map((t) => t.name);
+      expect(toolNames).toContain('get_vcon');
+      expect(toolNames).toContain('get_database_analytics');
+      expect(toolNames).toContain('get_database_shape');
+      expect(toolNames).not.toContain('create_vcon');
+      expect(toolNames).not.toContain('delete_vcon');
+    });
+
+    it('minimal profile should return only read and write tools (17 total)', () => {
+      process.env.MCP_TOOLS_PROFILE = 'minimal';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(allToolsWithCategories, config);
+      expect(filtered.length).toBe(17); // 8 read + 9 write
+
+      // Verify specific tools
+      const toolNames = filtered.map((t) => t.name);
+      expect(toolNames).toContain('get_vcon');
+      expect(toolNames).toContain('create_vcon');
+      expect(toolNames).not.toContain('get_schema');
+      expect(toolNames).not.toContain('get_database_analytics');
+    });
+  });
+
+  describe('Individual tool disabling', () => {
+    it('should disable delete_vcon with MCP_DISABLED_TOOLS', () => {
+      process.env.MCP_DISABLED_TOOLS = 'delete_vcon';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(allToolsWithCategories, config);
+
+      const toolNames = filtered.map((t) => t.name);
+      expect(toolNames).not.toContain('delete_vcon');
+      expect(filtered.length).toBe(29);
+    });
+
+    it('should disable multiple tools', () => {
+      process.env.MCP_DISABLED_TOOLS = 'delete_vcon,analyze_query,remove_all_tags';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(allToolsWithCategories, config);
+
+      const toolNames = filtered.map((t) => t.name);
+      expect(toolNames).not.toContain('delete_vcon');
+      expect(toolNames).not.toContain('analyze_query');
+      expect(toolNames).not.toContain('remove_all_tags');
+      expect(filtered.length).toBe(27);
+    });
+
+    it('should combine profile with disabled tools', () => {
+      process.env.MCP_TOOLS_PROFILE = 'user';
+      process.env.MCP_DISABLED_TOOLS = 'delete_vcon';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(allToolsWithCategories, config);
+
+      const toolNames = filtered.map((t) => t.name);
+      expect(toolNames).not.toContain('delete_vcon');
+      expect(toolNames).not.toContain('get_database_analytics'); // Excluded by profile
+      expect(filtered.length).toBe(18); // 19 - 1 disabled
+    });
+  });
+
+  describe('Category-based filtering', () => {
+    it('should enable only specified categories', () => {
+      process.env.MCP_ENABLED_CATEGORIES = 'read,schema';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(allToolsWithCategories, config);
+
+      expect(filtered.length).toBe(10);
+      filtered.forEach((tool) => {
+        expect(['read', 'schema']).toContain(tool.category);
+      });
+    });
+
+    it('should disable specified categories', () => {
+      process.env.MCP_DISABLED_CATEGORIES = 'analytics,infra';
+      const config = loadToolsConfig();
+      const filtered = filterEnabledTools(allToolsWithCategories, config);
+
+      expect(filtered.length).toBe(19); // 30 - 6 analytics - 5 infra
+      filtered.forEach((tool) => {
+        expect(['analytics', 'infra']).not.toContain(tool.category);
+      });
+    });
+  });
+
+  describe('Tool lookup for disabled check', () => {
+    it('should find tool definition by name', () => {
+      const toolName = 'delete_vcon';
+      const toolDef = allToolsWithCategories.find((t) => t.name === toolName);
+
+      expect(toolDef).toBeDefined();
+      expect(toolDef?.category).toBe('write');
+    });
+
+    it('should correctly identify if tool is disabled', () => {
+      process.env.MCP_TOOLS_PROFILE = 'readonly';
+      const config = loadToolsConfig();
+
+      // Check if delete_vcon would be filtered out
+      const toolDef = allToolsWithCategories.find((t) => t.name === 'delete_vcon');
+      expect(toolDef).toBeDefined();
+
+      const enabledTools = filterEnabledTools([toolDef!], config);
+      expect(enabledTools.length).toBe(0); // Should be filtered out
+    });
+
+    it('should correctly identify if tool is enabled', () => {
+      process.env.MCP_TOOLS_PROFILE = 'readonly';
+      const config = loadToolsConfig();
+
+      // Check if get_vcon would be included
+      const toolDef = allToolsWithCategories.find((t) => t.name === 'get_vcon');
+      expect(toolDef).toBeDefined();
+
+      const enabledTools = filterEnabledTools([toolDef!], config);
+      expect(enabledTools.length).toBe(1); // Should be included
+    });
+  });
+});
+


### PR DESCRIPTION
- Introduced a new `ToolCategory` type to categorize tools into `read`, `write`, `schema`, `analytics`, and `infra`.
- Updated multiple tool definitions across various files to include the appropriate category.
- Enhanced the README and documentation to reflect the new tool categorization and configuration options, allowing for better control over tool availability in different deployment scenarios.
- Implemented logic in the server handlers to filter tools based on enabled categories, improving the API's flexibility and usability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces category-based control over MCP tools with env-driven profiles and server enforcement.
> 
> - New `src/config/tools.ts`: defines `ToolCategory` (`read`, `write`, `schema`, `analytics`, `infra`), deployment profiles (`full`, `readonly`, `user`, `admin`, `minimal`), env vars (`MCP_TOOLS_PROFILE`, `MCP_ENABLED_CATEGORIES`, `MCP_DISABLED_CATEGORIES`, `MCP_DISABLED_TOOLS`), and helpers (`loadToolsConfig`, `filterEnabledTools`, `stripCategories`).
> - `src/server/handlers.ts`: loads config once, filters listed tools, strips `category` from responses, and blocks calls to disabled tools with `McpError`.
> - Adds `category` metadata across tool definitions (CRUD, templates, schema, tags, database, analytics, size tools) to enable filtering.
> - Docs: README, API Tools, Deployment, and Configuration guides updated with categories, examples, and profiles; tool count updated to 30.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7c06c27422ad133cf37802dcde62388c4960258. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->