### PR TITLE
Implement API key authentication for REST and MCP HTTP endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,15 @@ MCP_TRANSPORT=stdio
 # MCP_HTTP_DNS_PROTECTION=false
 # MCP_HTTP_ALLOWED_HOSTS=localhost,127.0.0.1
 # MCP_HTTP_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+# ============================================================================
+# API & MCP HTTP Auth (REST API and MCP endpoint when MCP_TRANSPORT=http)
+# ============================================================================
+# Comma-separated list of valid API keys. Clients send via header or Authorization: Bearer <key>
+# API_KEYS=key1,key2
+
+# Header for API key (default: authorization). Clients send Authorization: Bearer <key>. Set to x-api-key to use that header instead.
+# API_KEY_HEADER=authorization
+
+# Require auth for REST and MCP HTTP (default: true). Set to "false" to disable.
+# API_AUTH_REQUIRED=true

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ REST_API_BASE_PATH=/api/v1     # Base path for endpoints
 REST_API_ENABLED=true          # Enable/disable REST API
 
 # API Key Authentication
-VCON_API_KEYS=key1,key2        # Comma-separated valid API keys
+API_KEYS=key1,key2             # Comma-separated valid API keys
 API_AUTH_REQUIRED=true         # Set to false to disable auth
 ```
 
@@ -408,13 +408,13 @@ curl http://localhost:3000/api/v1/health
 # Create a vCon (requires API key)
 curl -X POST http://localhost:3000/api/v1/vcons \
   -H "Content-Type: application/json" \
-  -H "x-api-key: your-api-key" \
+  -H "Authorization: Bearer your-api-key" \
   -d '{"vcon":"0.3.0","subject":"Support Call","parties":[{"name":"Agent","tel":"+1111"}]}'
 
 # Batch create
 curl -X POST http://localhost:3000/api/v1/vcons/batch \
   -H "Content-Type: application/json" \
-  -H "x-api-key: your-api-key" \
+  -H "Authorization: Bearer your-api-key" \
   -d '[{"vcon":"0.3.0","parties":[{"name":"A","tel":"+1"}]},{"vcon":"0.3.0","parties":[{"name":"B","tel":"+2"}]}]'
 ```
 

--- a/docs/deployment/self-hosted-supabase.md
+++ b/docs/deployment/self-hosted-supabase.md
@@ -466,7 +466,7 @@ services:
       # Tool categories: read, write, schema, analytics, infra
       # Only enable read operations for production deployments
       - MCP_ENABLED_CATEGORIES=read
-      - VCON_API_KEYS=your-vcon-api-key
+      - API_KEYS=your-api-key
     labels:
       ofelia.enabled: "true"
       ofelia.job-exec.embed-vcons.schedule: "0 */10 * * *"
@@ -786,7 +786,7 @@ chains:
 | `SUPABASE_SERVICE_ROLE_KEY` | Service role JWT for admin access | Generated JWT |
 | `SUPABASE_ANON_KEY` | Anonymous user JWT | Generated JWT |
 | `MCP_ENABLED_CATEGORIES` | Enabled tool categories | `read` (for production) |
-| `VCON_API_KEYS` | API keys for authentication | Comma-separated keys |
+| `API_KEYS` | API keys for authentication | Comma-separated keys |
 
 ### 9.2 Embedding Provider Configuration
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,16 +1,18 @@
 /**
- * REST API Authentication Middleware for Koa
- * 
- * Provides API key authentication for REST endpoints
+ * REST API and MCP HTTP Authentication
+ *
+ * Provides API key authentication for REST and MCP HTTP endpoints.
+ * Default: Authorization: Bearer <token>. Override with API_KEY_HEADER (e.g. x-api-key) if needed.
  */
 
+import type { IncomingMessage } from 'http';
 import type { Context, Next } from 'koa';
 import { logWithContext } from '../observability/instrumentation.js';
 
 export interface AuthConfig {
   /** API keys that are allowed (comma-separated in env) */
   apiKeys: string[];
-  /** Header name for API key (default: x-api-key) */
+  /** Header name for API key (default: authorization, i.e. Authorization: Bearer <token>). */
   headerName: string;
   /** Whether auth is required (default: true) */
   required: boolean;
@@ -20,7 +22,7 @@ export interface AuthConfig {
  * Get auth configuration from environment
  */
 export function getAuthConfig(): AuthConfig {
-  const apiKeysEnv = process.env.VCON_API_KEYS || process.env.API_KEYS || '';
+  const apiKeysEnv = process.env.API_KEYS || '';
   const apiKeys = apiKeysEnv
     .split(',')
     .map(k => k.trim())
@@ -28,9 +30,92 @@ export function getAuthConfig(): AuthConfig {
 
   return {
     apiKeys,
-    headerName: process.env.API_KEY_HEADER || 'x-api-key',
+    headerName: process.env.API_KEY_HEADER || 'authorization',
     required: process.env.API_AUTH_REQUIRED !== 'false',
   };
+}
+
+/** Lower-case header name for lookup (Node headers are lower-cased) */
+function getHeader(req: IncomingMessage, name: string): string | undefined {
+  const raw = req.headers[name.toLowerCase()];
+  if (raw === undefined) return undefined;
+  return Array.isArray(raw) ? raw[0] : raw;
+}
+
+/**
+ * Extract token from request headers.
+ * With default header "authorization", reads Authorization: Bearer <token>. Else reads configured header.
+ */
+export function getTokenFromRequest(req: IncomingMessage, headerName: string): string | undefined {
+  const authHeader = getHeader(req, 'authorization');
+  if (authHeader?.trim().toLowerCase().startsWith('bearer ')) {
+    return authHeader.slice(7).trim() || undefined;
+  }
+  const value = getHeader(req, headerName);
+  return value?.trim() || undefined;
+}
+
+export type ValidateHttpAuthResult =
+  | { ok: true }
+  | { ok: false; statusCode: number; body: object; wwwAuth?: string };
+
+/**
+ * Validate auth for a raw HTTP request (e.g. MCP endpoint).
+ * Reuses same config as REST API (API_KEYS, API_KEY_HEADER, API_AUTH_REQUIRED).
+ */
+export function validateHttpRequestAuth(
+  req: IncomingMessage,
+  config: AuthConfig
+): ValidateHttpAuthResult {
+  if (!config.required) {
+    return { ok: true };
+  }
+  if (config.apiKeys.length === 0) {
+    logWithContext('error', 'MCP auth required but no API keys configured - blocking request', {
+      hint: 'Set API_KEYS, or set API_AUTH_REQUIRED=false',
+    });
+    return {
+      ok: false,
+      statusCode: 503,
+      body: {
+        error: 'Service Unavailable',
+        message: 'MCP authentication is required but not configured.',
+        hint:
+          process.env.NODE_ENV !== 'production'
+            ? 'Set API_KEYS env var, or set API_AUTH_REQUIRED=false'
+            : undefined,
+      },
+    };
+  }
+
+  const token = getTokenFromRequest(req, config.headerName);
+  if (!token) {
+    return {
+      ok: false,
+      statusCode: 401,
+      wwwAuth: 'Bearer realm="vCon MCP"',
+      body: {
+        error: 'Unauthorized',
+        message:
+          config.headerName === 'authorization'
+            ? 'Missing Authorization: Bearer <token> header'
+            : `Missing ${config.headerName} or Authorization: Bearer <token> header`,
+      },
+    };
+  }
+  if (!config.apiKeys.includes(token)) {
+    logWithContext('warn', 'Invalid MCP auth token attempted', {
+      remote_address: req.socket?.remoteAddress,
+      token_prefix: token.substring(0, 8) + '...',
+    });
+    return {
+      ok: false,
+      statusCode: 401,
+      wwwAuth: 'Bearer realm="vCon MCP"',
+      body: { error: 'Unauthorized', message: 'Invalid token' },
+    };
+  }
+  return { ok: true };
 }
 
 /**
@@ -51,7 +136,7 @@ export function createAuthMiddleware(config?: Partial<AuthConfig>) {
     if (authConfig.apiKeys.length === 0) {
       logWithContext('error', 'API auth required but no API keys configured - blocking request', {
         path: ctx.path,
-        hint: 'Set VCON_API_KEYS or API_KEYS environment variable, or set API_AUTH_REQUIRED=false to disable auth',
+        hint: 'Set API_KEYS environment variable, or set API_AUTH_REQUIRED=false to disable auth',
       });
 
       ctx.status = 503;
@@ -59,21 +144,27 @@ export function createAuthMiddleware(config?: Partial<AuthConfig>) {
         error: 'Service Unavailable',
         message: 'API authentication is required but not configured. Please contact the administrator.',
         hint: process.env.NODE_ENV !== 'production' 
-          ? 'Set VCON_API_KEYS or API_KEYS env var, or set API_AUTH_REQUIRED=false' 
+          ? 'Set API_KEYS env var, or set API_AUTH_REQUIRED=false' 
           : undefined,
       };
       return;
     }
 
-    // Get API key from header
-    const apiKey = ctx.get(authConfig.headerName);
+    // Get API key: support Authorization: Bearer <token> (MockMCP-style) and configured header
+    const authHeader = ctx.get('authorization');
+    const apiKey = authHeader?.trim().toLowerCase().startsWith('bearer ')
+      ? authHeader.slice(7).trim()
+      : (ctx.get(authConfig.headerName) || '').trim();
 
     if (!apiKey) {
       ctx.status = 401;
-      ctx.set('WWW-Authenticate', 'ApiKey realm="vCon API"');
+      ctx.set('WWW-Authenticate', 'Bearer realm="vCon API"');
       ctx.body = {
         error: 'Unauthorized',
-        message: `Missing ${authConfig.headerName} header`,
+        message:
+          authConfig.headerName === 'authorization'
+            ? 'Missing Authorization: Bearer <token> header'
+            : `Missing ${authConfig.headerName} header`,
       };
       return;
     }
@@ -86,7 +177,7 @@ export function createAuthMiddleware(config?: Partial<AuthConfig>) {
       });
 
       ctx.status = 401;
-      ctx.set('WWW-Authenticate', 'ApiKey realm="vCon API"');
+      ctx.set('WWW-Authenticate', 'Bearer realm="vCon API"');
       ctx.body = {
         error: 'Unauthorized',
         message: 'Invalid API key',

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,8 +4,15 @@
  * Exports Koa-based REST API components for vCon ingestion and operations
  */
 
-export { createAuthMiddleware, errorHandler, getAuthConfig, requestLogger } from './auth.js';
-export type { AuthConfig } from './auth.js';
+export {
+  createAuthMiddleware,
+  errorHandler,
+  getAuthConfig,
+  getTokenFromRequest,
+  requestLogger,
+  validateHttpRequestAuth,
+} from './auth.js';
+export type { AuthConfig, ValidateHttpAuthResult } from './auth.js';
 
 export { createRestApi, getRestApiConfig, isRestApiPath } from './rest-router.js';
 export type { RestApiConfig, RestApiContext } from './rest-router.js';

--- a/tests/api/auth.test.ts
+++ b/tests/api/auth.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for REST and MCP HTTP auth (getTokenFromRequest, validateHttpRequestAuth)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IncomingMessage } from 'http';
+import {
+  getAuthConfig,
+  getTokenFromRequest,
+  validateHttpRequestAuth,
+} from '../../src/api/auth.js';
+
+vi.mock('../../src/observability/instrumentation.js', () => ({
+  logWithContext: vi.fn(),
+}));
+
+function mockReq(headers: Record<string, string>): IncomingMessage {
+  return {
+    headers: { ...headers },
+    socket: { remoteAddress: '127.0.0.1' },
+  } as IncomingMessage;
+}
+
+describe('getTokenFromRequest', () => {
+  it('extracts Bearer token from Authorization header (default)', () => {
+    const req = mockReq({ authorization: 'Bearer sk-secret-123' });
+    expect(getTokenFromRequest(req, 'authorization')).toBe('sk-secret-123');
+  });
+
+  it('extracts token from custom header when API_KEY_HEADER is set', () => {
+    const req = mockReq({ 'x-api-key': 'my-api-key' });
+    expect(getTokenFromRequest(req, 'x-api-key')).toBe('my-api-key');
+  });
+
+  it('returns undefined when no auth header', () => {
+    const req = mockReq({});
+    expect(getTokenFromRequest(req, 'authorization')).toBeUndefined();
+  });
+});
+
+describe('validateHttpRequestAuth', () => {
+  beforeEach(() => {
+    vi.stubEnv('API_AUTH_REQUIRED', 'true');
+    vi.stubEnv('API_KEYS', 'key1,key2');
+  });
+
+  it('returns ok when auth not required', () => {
+    const config = { ...getAuthConfig(), required: false };
+    const req = mockReq({});
+    expect(validateHttpRequestAuth(req, config)).toEqual({ ok: true });
+  });
+
+  it('returns ok when Authorization Bearer token is valid (default)', () => {
+    const config = getAuthConfig();
+    const req = mockReq({ authorization: 'Bearer key1' });
+    expect(validateHttpRequestAuth(req, config)).toEqual({ ok: true });
+  });
+
+  it('returns ok when custom header is valid (API_KEY_HEADER override)', () => {
+    const config = { ...getAuthConfig(), headerName: 'x-api-key' };
+    const req = mockReq({ 'x-api-key': 'key2' });
+    expect(validateHttpRequestAuth(req, config)).toEqual({ ok: true });
+  });
+
+  it('returns 401 when token missing and auth required', () => {
+    const config = getAuthConfig();
+    const req = mockReq({});
+    const result = validateHttpRequestAuth(req, config);
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.statusCode).toBe(401);
+      expect(result.body).toMatchObject({ error: 'Unauthorized' });
+      expect(result.wwwAuth).toContain('Bearer');
+    }
+  });
+
+  it('returns 401 when token invalid', () => {
+    const config = getAuthConfig();
+    const req = mockReq({ authorization: 'Bearer wrong-key' });
+    const result = validateHttpRequestAuth(req, config);
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.statusCode).toBe(401);
+      expect(result.body).toMatchObject({ error: 'Unauthorized', message: 'Invalid token' });
+    }
+  });
+});


### PR DESCRIPTION
- Updated environment variable names from VCON_API_KEYS to API_KEYS for consistency.
- Introduced support for Authorization: Bearer <token> header for API key authentication.
- Enhanced documentation to reflect changes in API key usage and authentication requirements.
- Added tests for authentication functions to ensure correct behavior for token extraction and validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication paths for both REST and MCP HTTP; misconfiguration or header changes could unintentionally block clients, though behavior is covered by unit tests and primarily config-driven.
> 
> **Overview**
> **Unifies API key authentication across REST API and MCP HTTP transport.** REST auth now defaults to `Authorization: Bearer <token>` (with optional `API_KEY_HEADER` override) and standardizes on `API_KEYS` (dropping `VCON_API_KEYS`).
> 
> **Adds auth enforcement to the MCP HTTP endpoint.** `src/transport/http.ts` now validates incoming MCP HTTP requests with the same config and returns structured `401/503` responses (including `WWW-Authenticate: Bearer`).
> 
> Documentation and deployment examples are updated to the new env vars/headers, and new Vitest coverage is added for token extraction and HTTP auth validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e19098e9a4c78bdded0c311a9011544ecada833. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->