### PR TITLE
Update vCon version handling to accept any string or missing value

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -76,7 +76,7 @@ export class VConQueries {
         .insert({
           id: vcon.uuid,     // Explicitly set id to match uuid
           uuid: vcon.uuid,
-          vcon_version: vcon.vcon,
+          vcon_version: vcon.vcon ?? '0.3.0',
           subject: vcon.subject,
           created_at: vcon.created_at,
           updated_at: vcon.updated_at,

--- a/src/types/vcon.ts
+++ b/src/types/vcon.ts
@@ -17,6 +17,7 @@
 // Type Definitions
 // ============================================================================
 
+/** @deprecated Version field is deprecated; any string or missing is accepted. Kept for compatibility. */
 export type VConVersion = '0.3.0';
 export type Encoding = 'base64url' | 'json' | 'none';
 export type DialogType = 'recording' | 'text' | 'transfer' | 'incomplete';
@@ -212,7 +213,8 @@ export interface Group {
  * ✅ CORRECTED: Added appended per spec Section 4.1.9
  */
 export interface VCon {
-  vcon: VConVersion;
+  /** Version string (deprecated). Any value or missing is accepted; default '0.3.0' when normalizing. */
+  vcon?: string;
   uuid: string;
   extensions?: string[];    // ✅ Section 4.1.3 - Extension identifiers
   must_support?: string[];  // ✅ Section 4.1.4 - Required extension support

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -32,8 +32,7 @@ export class VConValidator {
     this.errors = [];
     this.warnings = [];
 
-    // Core vCon validation
-    this.validateVConVersion(vcon);
+    // Core vCon validation (vcon version field is deprecated - accept any value or missing)
     this.validateUUID(vcon.uuid);
     this.validateDates(vcon);
     this.validateParties(vcon.parties);
@@ -49,12 +48,6 @@ export class VConValidator {
       errors: this.errors,
       warnings: this.warnings
     };
-  }
-
-  private validateVConVersion(vcon: VCon): void {
-    if (vcon.vcon !== '0.3.0') {
-      this.errors.push(`Invalid vcon version: ${vcon.vcon}. Must be '0.3.0'`);
-    }
   }
 
   private validateUUID(uuid: string): void {

--- a/tests/vcon-compliance.test.ts
+++ b/tests/vcon-compliance.test.ts
@@ -296,6 +296,70 @@ describe('IETF vCon Spec Compliance', () => {
   });
 
   // ==========================================================================
+  // Version field (deprecated): accept any value or missing
+  // ==========================================================================
+  describe('vcon version field (relaxed: any value or missing accepted)', () => {
+    it('should accept vcon version 0.0.1', () => {
+      const vcon = {
+        vcon: '0.0.1',
+        uuid: randomUUID(),
+        created_at: new Date().toISOString(),
+        parties: [{ name: 'Test', tel: '+15551234567' }],
+      } as VCon;
+      const result = validateVCon(vcon);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should accept vcon version 1.0.0', () => {
+      const vcon = {
+        vcon: '1.0.0',
+        uuid: randomUUID(),
+        created_at: new Date().toISOString(),
+        parties: [{ name: 'Test' }],
+      } as VCon;
+      const result = validateVCon(vcon);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should accept vcon when vcon field is missing', () => {
+      const vcon = {
+        uuid: randomUUID(),
+        created_at: new Date().toISOString(),
+        parties: [{ name: 'Test', mailto: 'test@example.com' }],
+      } as VCon;
+      const result = validateVCon(vcon);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should accept sample Crexendo-style vcon with vcon "0.0.1"', () => {
+      const sampleVcon = {
+        vcon: '0.0.1',
+        uuid: '019c9896-7570-86d4-9dd8-dd37220d739c',
+        created_at: '2026-02-26T06:15:23.248460+00:00',
+        parties: [
+          { id: '+19782250878_None_744', tel: '+19782250878', name: null, role: 'customer', mailto: null },
+          { id: 'scott.henshaw@strolid.com', tel: '+15593660701', name: 'Scott Henshaw', role: 'agent', mailto: 'scott.henshaw@strolid.com' },
+        ],
+        dialog: [{
+          type: 'recording',
+          start: '2026-02-26T06:13:12.811092+00:00',
+          duration: 4,
+          parties: [1, 0],
+          url: 'https://example.com/rec.wav',
+          content_hash: 'abc',
+        }],
+        attachments: [{ type: 'ingress_info', encoding: 'none', body: { source: 'crexendo' } }],
+      } as unknown as VCon;
+      const result = validateVCon(sampleVcon);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  // ==========================================================================
   // Integration Tests
   // ==========================================================================
   describe('Complete vCon Validation', () => {


### PR DESCRIPTION
- Modified the vcon_version field to default to '0.3.0' if not provided.
- Updated VCon interface to mark the vcon field as deprecated, allowing any string or absence of value.
- Removed strict validation for vcon version, simplifying the validation logic.
- Added tests to ensure acceptance of various vcon version inputs, including missing values.