### PR TITLE
Fix Bearer token extraction on headers with leading whitespace

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -48,8 +48,9 @@ function getHeader(req: IncomingMessage, name: string): string | undefined {
  */
 export function getTokenFromRequest(req: IncomingMessage, headerName: string): string | undefined {
   const authHeader = getHeader(req, 'authorization');
-  if (authHeader?.trim().toLowerCase().startsWith('bearer ')) {
-    return authHeader.slice(7).trim() || undefined;
+  const trimmedAuthHeader = authHeader?.trim();
+  if (trimmedAuthHeader?.toLowerCase().startsWith('bearer ')) {
+    return trimmedAuthHeader.slice(7).trim() || undefined;
   }
   const value = getHeader(req, headerName);
   return value?.trim() || undefined;
@@ -152,8 +153,9 @@ export function createAuthMiddleware(config?: Partial<AuthConfig>) {
 
     // Get API key: support Authorization: Bearer <token> (MockMCP-style) and configured header
     const authHeader = ctx.get('authorization');
-    const apiKey = authHeader?.trim().toLowerCase().startsWith('bearer ')
-      ? authHeader.slice(7).trim()
+    const trimmedAuthHeader = authHeader?.trim();
+    const apiKey = trimmedAuthHeader?.toLowerCase().startsWith('bearer ')
+      ? trimmedAuthHeader.slice(7).trim()
       : (ctx.get(authConfig.headerName) || '').trim();
 
     if (!apiKey) {


### PR DESCRIPTION
## Summary

- Fixes bug identified in PR #31 review: `authHeader.slice(7)` was applied to the original untrimmed string while the `startsWith('bearer ')` check used `.trim()`, causing corrupted token extraction if the `Authorization` header had leading whitespace
- Applied the same fix to both locations: `getTokenFromRequest` (HTTP) and the Koa middleware

## Test plan

- [ ] Verify that `Authorization: Bearer <token>` (normal) still works
- [ ] Verify that `Authorization:  Bearer <token>` (leading whitespace) now extracts the correct token
- [ ] Check both REST and MCP HTTP endpoints authenticate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)