### PR TITLE
fix: upsert vCon on duplicate UUID submission

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -69,11 +69,11 @@ export class VConQueries {
         }
       }
 
-      // Insert main vcon
+      // Upsert main vcon — idempotent on re-submission of same UUID
       // Set id = uuid so they match (id is the PK, uuid is the vCon document UUID)
       const { data: vconData, error: vconError } = await this.supabase
         .from('vcons')
-        .insert({
+        .upsert({
           id: vcon.uuid,     // Explicitly set id to match uuid
           uuid: vcon.uuid,
           vcon_version: vcon.vcon ?? '0.3.0',
@@ -85,7 +85,7 @@ export class VConQueries {
           redacted: vcon.redacted || {},
           appended: vcon.appended || {},        // ✅ Added per spec
           tenant_id: tenantId,                  // ✅ Added for RLS multi-tenant support
-        })
+        }, { onConflict: 'id' })
         .select('id, uuid')
         .single();
 
@@ -96,6 +96,14 @@ export class VConQueries {
         }, 'Database query errors');
         throw vconError;
       }
+
+      // Delete existing child rows so re-submission replaces them cleanly
+      await Promise.all([
+        this.supabase.from('parties').delete().eq('vcon_id', vconData.id),
+        this.supabase.from('dialog').delete().eq('vcon_id', vconData.id),
+        this.supabase.from('analysis').delete().eq('vcon_id', vconData.id),
+        this.supabase.from('attachments').delete().eq('vcon_id', vconData.id),
+      ]);
 
     // Insert parties
     if (vcon.parties.length > 0) {

--- a/tests/db-queries.test.ts
+++ b/tests/db-queries.test.ts
@@ -19,6 +19,7 @@ describe('VConQueries', () => {
         from: vi.fn(),
         select: vi.fn(),
         insert: vi.fn(),
+        upsert: vi.fn(),
         update: vi.fn(),
         delete: vi.fn(),
         eq: vi.fn(),
@@ -70,7 +71,7 @@ describe('VConQueries', () => {
 
       expect(result.uuid).toBe(testVCon.uuid);
       expect(mockSupabase.from).toHaveBeenCalledWith('vcons');
-      expect(mockSupabase.insert).toHaveBeenCalled();
+      expect(mockSupabase.upsert).toHaveBeenCalled();
     });
 
     it('should create vCon with all components (dialog, analysis, attachments)', async () => {


### PR DESCRIPTION
## Summary
- Replaced `.insert()` with `.upsert({ onConflict: 'id' })` for the main vcon row so re-submissions don't throw a 500 duplicate key error
- Added child row cleanup (parties, dialog, analysis, attachments) before re-inserting, so the second submission fully replaces the first

## Test plan
- [ ] POST same vcon UUID twice → both return 201
- [ ] Second POST returns updated subject, parties, and dialog (not the first submission's data)
- [ ] New vcon UUIDs still insert normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)