### PR TITLE
feat: date-scoped content analytics and daily report workflow

### DIFF
--- a/src/db/database-analytics.ts
+++ b/src/db/database-analytics.ts
@@ -229,10 +229,15 @@ export class SupabaseDatabaseAnalytics implements IDatabaseAnalytics {
       includePartyPatterns = true,
       includeConversationMetrics = true,
       includeTemporalContent = false,
+      startDate,
+      endDate,
     } = options;
+
+    const dateFilter = this.buildDateFilter(startDate, endDate);
 
     const analytics: any = {
       timestamp: new Date().toISOString(),
+      ...(startDate || endDate ? { date_range: { start_date: startDate || null, end_date: endDate || null } } : {}),
       summary: {},
       dialog_analysis: {},
       analysis_breakdown: {},
@@ -242,31 +247,27 @@ export class SupabaseDatabaseAnalytics implements IDatabaseAnalytics {
     };
 
     // Get basic content statistics
-    const contentStats = await this.getContentStatistics();
+    const contentStats = await this.getContentStatistics(dateFilter);
     analytics.summary = contentStats;
 
     // Dialog analysis
     if (includeDialogAnalysis) {
-      const dialogAnalysis = await this.getDialogAnalysis();
-      analytics.dialog_analysis = dialogAnalysis;
+      analytics.dialog_analysis = await this.getDialogAnalysis(dateFilter);
     }
 
     // Analysis breakdown
     if (includeAnalysisBreakdown) {
-      const analysisBreakdown = await this.getAnalysisBreakdown();
-      analytics.analysis_breakdown = analysisBreakdown;
+      analytics.analysis_breakdown = await this.getAnalysisBreakdown(dateFilter);
     }
 
     // Party patterns
     if (includePartyPatterns) {
-      const partyPatterns = await this.getPartyPatterns();
-      analytics.party_patterns = partyPatterns;
+      analytics.party_patterns = await this.getPartyPatterns(dateFilter);
     }
 
     // Conversation metrics
     if (includeConversationMetrics) {
-      const conversationMetrics = await this.getConversationMetrics();
-      analytics.conversation_metrics = conversationMetrics;
+      analytics.conversation_metrics = await this.getConversationMetrics(dateFilter);
     }
 
     // Temporal content
@@ -406,6 +407,16 @@ export class SupabaseDatabaseAnalytics implements IDatabaseAnalytics {
     if (bytes === 0) return '0 Bytes';
     const i = Math.floor(Math.log(bytes) / Math.log(1024));
     return Math.round(bytes / Math.pow(1024, i) * 100) / 100 + ' ' + sizes[i];
+  }
+
+  private buildDateFilter(startDate?: string, endDate?: string): { vconWhere: string } {
+    if (!startDate && !endDate) {
+      return { vconWhere: '' };
+    }
+    const conditions: string[] = [];
+    if (startDate) conditions.push(`v.created_at >= '${startDate}'`);
+    if (endDate) conditions.push(`v.created_at < '${endDate}'`);
+    return { vconWhere: `WHERE ${conditions.join(' AND ')}` };
   }
 
   private async calculateHealthScore(): Promise<number> {
@@ -851,9 +862,22 @@ export class SupabaseDatabaseAnalytics implements IDatabaseAnalytics {
     return data || [];
   }
 
-  private async getContentStatistics() {
-    const query = `
-      SELECT 
+  private async getContentStatistics(dateFilter: { vconWhere: string } = { vconWhere: '' }) {
+    const hasDateFilter = dateFilter.vconWhere !== '';
+    const query = hasDateFilter ? `
+      WITH filtered_vcons AS (
+        SELECT id FROM vcons v ${dateFilter.vconWhere}
+      )
+      SELECT
+        (SELECT COUNT(*) FROM filtered_vcons) as total_vcons,
+        (SELECT COUNT(*) FROM parties WHERE vcon_id IN (SELECT id FROM filtered_vcons)) as total_parties,
+        (SELECT COUNT(*) FROM dialog WHERE vcon_id IN (SELECT id FROM filtered_vcons)) as total_dialogs,
+        (SELECT COUNT(*) FROM analysis WHERE vcon_id IN (SELECT id FROM filtered_vcons)) as total_analysis,
+        (SELECT COUNT(*) FROM attachments WHERE vcon_id IN (SELECT id FROM filtered_vcons)) as total_attachments,
+        (SELECT SUM(COALESCE(duration_seconds, 0)) FROM dialog WHERE vcon_id IN (SELECT id FROM filtered_vcons)) as total_duration_seconds,
+        (SELECT AVG(COALESCE(duration_seconds, 0)) FROM dialog WHERE vcon_id IN (SELECT id FROM filtered_vcons) AND duration_seconds > 0) as avg_duration_seconds
+    ` : `
+      SELECT
         (SELECT COUNT(*) FROM vcons) as total_vcons,
         (SELECT COUNT(*) FROM parties) as total_parties,
         (SELECT COUNT(*) FROM dialog) as total_dialogs,
@@ -872,9 +896,26 @@ export class SupabaseDatabaseAnalytics implements IDatabaseAnalytics {
     return data && data.length > 0 ? data[0] : {};
   }
 
-  private async getDialogAnalysis() {
-    const query = `
-      SELECT 
+  private async getDialogAnalysis(dateFilter: { vconWhere: string } = { vconWhere: '' }) {
+    const hasDateFilter = dateFilter.vconWhere !== '';
+    const query = hasDateFilter ? `
+      WITH filtered_vcons AS (
+        SELECT id FROM vcons v ${dateFilter.vconWhere}
+      )
+      SELECT
+        type,
+        COUNT(*) as count,
+        AVG(COALESCE(duration_seconds, 0)) as avg_duration,
+        SUM(COALESCE(duration_seconds, 0)) as total_duration,
+        SUM(COALESCE(size_bytes, 0)) as total_size,
+        AVG(COALESCE(size_bytes, 0)) as avg_size,
+        COUNT(DISTINCT vcon_id) as unique_vcons
+      FROM dialog
+      WHERE vcon_id IN (SELECT id FROM filtered_vcons)
+      GROUP BY type
+      ORDER BY count DESC
+    ` : `
+      SELECT
         type,
         COUNT(*) as count,
         AVG(COALESCE(duration_seconds, 0)) as avg_duration,
@@ -896,9 +937,24 @@ export class SupabaseDatabaseAnalytics implements IDatabaseAnalytics {
     return data || [];
   }
 
-  private async getAnalysisBreakdown() {
-    const query = `
-      SELECT 
+  private async getAnalysisBreakdown(dateFilter: { vconWhere: string } = { vconWhere: '' }) {
+    const hasDateFilter = dateFilter.vconWhere !== '';
+    const query = hasDateFilter ? `
+      WITH filtered_vcons AS (
+        SELECT id FROM vcons v ${dateFilter.vconWhere}
+      )
+      SELECT
+        type,
+        vendor,
+        COUNT(*) as count,
+        AVG(COALESCE(confidence, 0)) as avg_confidence,
+        COUNT(DISTINCT vcon_id) as unique_vcons
+      FROM analysis
+      WHERE vcon_id IN (SELECT id FROM filtered_vcons)
+      GROUP BY type, vendor
+      ORDER BY count DESC
+    ` : `
+      SELECT
         type,
         vendor,
         COUNT(*) as count,
@@ -918,18 +974,35 @@ export class SupabaseDatabaseAnalytics implements IDatabaseAnalytics {
     return data || [];
   }
 
-  private async getPartyPatterns() {
-    const query = `
-      SELECT 
-        role,
-        COUNT(*) as count,
+  private async getPartyPatterns(dateFilter: { vconWhere: string } = { vconWhere: '' }) {
+    const hasDateFilter = dateFilter.vconWhere !== '';
+    // parties table has no 'role' column — group by identifier type instead
+    const query = hasDateFilter ? `
+      WITH filtered_vcons AS (
+        SELECT id FROM vcons v ${dateFilter.vconWhere}
+      )
+      SELECT
+        COUNT(*) as total_parties,
         COUNT(DISTINCT name) as unique_names,
         COUNT(DISTINCT mailto) as unique_emails,
         COUNT(DISTINCT tel) as unique_phones,
-        COUNT(DISTINCT vcon_id) as unique_vcons
+        COUNT(DISTINCT vcon_id) as unique_vcons,
+        SUM(CASE WHEN tel IS NOT NULL THEN 1 ELSE 0 END) as parties_with_phone,
+        SUM(CASE WHEN mailto IS NOT NULL THEN 1 ELSE 0 END) as parties_with_email,
+        SUM(CASE WHEN name IS NOT NULL THEN 1 ELSE 0 END) as parties_with_name
       FROM parties
-      GROUP BY role
-      ORDER BY count DESC
+      WHERE vcon_id IN (SELECT id FROM filtered_vcons)
+    ` : `
+      SELECT
+        COUNT(*) as total_parties,
+        COUNT(DISTINCT name) as unique_names,
+        COUNT(DISTINCT mailto) as unique_emails,
+        COUNT(DISTINCT tel) as unique_phones,
+        COUNT(DISTINCT vcon_id) as unique_vcons,
+        SUM(CASE WHEN tel IS NOT NULL THEN 1 ELSE 0 END) as parties_with_phone,
+        SUM(CASE WHEN mailto IS NOT NULL THEN 1 ELSE 0 END) as parties_with_email,
+        SUM(CASE WHEN name IS NOT NULL THEN 1 ELSE 0 END) as parties_with_name
+      FROM parties
     `;
 
     const { data, error } = await this.supabase.rpc('exec_sql', {
@@ -941,16 +1014,61 @@ export class SupabaseDatabaseAnalytics implements IDatabaseAnalytics {
     return data || [];
   }
 
-  private async getConversationMetrics() {
-    const query = `
+  private async getConversationMetrics(dateFilter: { vconWhere: string } = { vconWhere: '' }) {
+    const hasDateFilter = dateFilter.vconWhere !== '';
+    // When date-filtered, use pre-aggregated CTEs to avoid cartesian explosion
+    // from 4-way LEFT JOIN. Each child table is aggregated independently first.
+    const query = hasDateFilter ? `
+      WITH filtered_vcons AS (
+        SELECT id FROM vcons v ${dateFilter.vconWhere}
+      ),
+      party_counts AS (
+        SELECT vcon_id, COUNT(*) as cnt
+        FROM parties WHERE vcon_id IN (SELECT id FROM filtered_vcons)
+        GROUP BY vcon_id
+      ),
+      dialog_counts AS (
+        SELECT vcon_id, COUNT(*) as cnt,
+          SUM(COALESCE(duration_seconds, 0)) as dur,
+          SUM(COALESCE(size_bytes, 0)) as sz
+        FROM dialog WHERE vcon_id IN (SELECT id FROM filtered_vcons)
+        GROUP BY vcon_id
+      ),
+      analysis_counts AS (
+        SELECT vcon_id, COUNT(*) as cnt
+        FROM analysis WHERE vcon_id IN (SELECT id FROM filtered_vcons)
+        GROUP BY vcon_id
+      ),
+      attachment_counts AS (
+        SELECT vcon_id, COUNT(*) as cnt
+        FROM attachments WHERE vcon_id IN (SELECT id FROM filtered_vcons)
+        GROUP BY vcon_id
+      )
+      SELECT
+        COUNT(*) as total_conversations,
+        AVG(COALESCE(pc.cnt, 0)) as avg_parties_per_conversation,
+        AVG(COALESCE(dc.cnt, 0)) as avg_dialogs_per_conversation,
+        AVG(COALESCE(ac.cnt, 0)) as avg_analysis_per_conversation,
+        AVG(COALESCE(atc.cnt, 0)) as avg_attachments_per_conversation,
+        AVG(COALESCE(dc.dur, 0)) as avg_duration_per_conversation,
+        AVG(COALESCE(dc.sz, 0)) as avg_size_per_conversation,
+        MAX(COALESCE(pc.cnt, 0)) as max_parties_in_conversation,
+        MAX(COALESCE(dc.cnt, 0)) as max_dialogs_in_conversation,
+        SUM(CASE WHEN COALESCE(dc.cnt, 0) = 0 THEN 1 ELSE 0 END) as vcons_without_dialog,
+        SUM(CASE WHEN COALESCE(ac.cnt, 0) = 0 THEN 1 ELSE 0 END) as vcons_without_analysis
+      FROM filtered_vcons fv
+      LEFT JOIN party_counts pc ON pc.vcon_id = fv.id
+      LEFT JOIN dialog_counts dc ON dc.vcon_id = fv.id
+      LEFT JOIN analysis_counts ac ON ac.vcon_id = fv.id
+      LEFT JOIN attachment_counts atc ON atc.vcon_id = fv.id
+    ` : `
       WITH conversation_metrics AS (
-        SELECT 
+        SELECT
           v.id as vcon_id,
-          v.subject,
           COUNT(DISTINCT p.id) as party_count,
-          COUNT(d.id) as dialog_count,
-          COUNT(an.id) as analysis_count,
-          COUNT(att.id) as attachment_count,
+          COUNT(DISTINCT d.id) as dialog_count,
+          COUNT(DISTINCT an.id) as analysis_count,
+          COUNT(DISTINCT att.id) as attachment_count,
           SUM(COALESCE(d.duration_seconds, 0)) as total_duration,
           SUM(COALESCE(d.size_bytes, 0)) as total_size
         FROM vcons v
@@ -958,9 +1076,9 @@ export class SupabaseDatabaseAnalytics implements IDatabaseAnalytics {
         LEFT JOIN dialog d ON d.vcon_id = v.id
         LEFT JOIN analysis an ON an.vcon_id = v.id
         LEFT JOIN attachments att ON att.vcon_id = v.id
-        GROUP BY v.id, v.subject
+        GROUP BY v.id
       )
-      SELECT 
+      SELECT
         COUNT(*) as total_conversations,
         AVG(party_count) as avg_parties_per_conversation,
         AVG(dialog_count) as avg_dialogs_per_conversation,
@@ -969,7 +1087,9 @@ export class SupabaseDatabaseAnalytics implements IDatabaseAnalytics {
         AVG(total_duration) as avg_duration_per_conversation,
         AVG(total_size) as avg_size_per_conversation,
         MAX(party_count) as max_parties_in_conversation,
-        MAX(dialog_count) as max_dialogs_in_conversation
+        MAX(dialog_count) as max_dialogs_in_conversation,
+        SUM(CASE WHEN dialog_count = 0 THEN 1 ELSE 0 END) as vcons_without_dialog,
+        SUM(CASE WHEN analysis_count = 0 THEN 1 ELSE 0 END) as vcons_without_analysis
       FROM conversation_metrics
     `;
 

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -73,6 +73,8 @@ export interface ContentAnalyticsOptions {
     includePartyPatterns?: boolean;
     includeConversationMetrics?: boolean;
     includeTemporalContent?: boolean;
+    startDate?: string;
+    endDate?: string;
 }
 
 export interface DatabaseHealthOptions {

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -181,6 +181,27 @@ export const findSimilarPrompt: PromptDefinition = {
 };
 
 /**
+ * Prompt: Generate Daily Activity Report
+ * Use case: "Generate a report of yesterday's activity" or "What happened on April 13?"
+ */
+export const dailyReportPrompt: PromptDefinition = {
+  name: 'daily_activity_report',
+  description: 'Generate a comprehensive daily activity report for a specific date. Uses analytics tools and targeted searches instead of manual sampling for accurate, efficient reporting.',
+  arguments: [
+    {
+      name: 'date',
+      description: 'The date to report on in YYYY-MM-DD format (e.g., "2026-04-13"). Defaults to yesterday.',
+      required: false
+    },
+    {
+      name: 'focus_areas',
+      description: 'Optional focus areas for the report (e.g., "dealership coverage, notable conversations, agent activity")',
+      required: false
+    }
+  ]
+};
+
+/**
  * Prompt: Analyze Query Strategy
  * Use case: Help users understand which search approach to use
  */
@@ -208,7 +229,8 @@ export const allPrompts: PromptDefinition[] = [
   discoverTagsPrompt,
   complexSearchPrompt,
   findSimilarPrompt,
-  queryStrategyPrompt
+  queryStrategyPrompt,
+  dailyReportPrompt
 ];
 
 /**
@@ -241,6 +263,8 @@ export function generatePromptMessage(name: string, args: Record<string, string>
       return generateFindSimilarMessage(args);
     case 'help_me_search':
       return generateQueryStrategyMessage(args);
+    case 'daily_activity_report':
+      return generateDailyReportMessage(args);
     default:
       return 'Unknown prompt';
   }
@@ -860,4 +884,105 @@ Based on analysis, here's the recommended approach for "${whatYouWant}":
 `;
 }
 
+function generateDailyReportMessage(args: Record<string, string>): string {
+  const date = args.date || 'yesterday';
+  const focusAreas = args.focus_areas || '';
 
+  return `Generate a daily activity report for: ${date}${focusAreas ? `\nFocus areas: ${focusAreas}` : ''}
+
+## Workflow: Daily Activity Report
+
+Follow these steps IN ORDER. Do NOT skip to sampling individual vCons before completing the aggregate steps.
+
+### Step 1: Get Exact Daily Volume (1 tool call)
+Use \`get_monthly_growth_analytics\` to get the precise vCon count for the target date:
+\`\`\`json
+{
+  "granularity": "daily",
+  "months_back": 1
+}
+\`\`\`
+Find the row matching ${date} in the results. This gives you the exact count — do not estimate from samples.
+
+### Step 2: Get Date-Scoped Content Analytics (1 tool call)
+Use \`get_content_analytics\` with date filtering to get aggregate breakdowns for just this day:
+\`\`\`json
+{
+  "start_date": "${date}T00:00:00Z",
+  "end_date": "[next day]T00:00:00Z",
+  "include_dialog_analysis": true,
+  "include_analysis_breakdown": true,
+  "include_party_patterns": true,
+  "include_conversation_metrics": true
+}
+\`\`\`
+This returns:
+- Dialog type breakdown (recording, text, transfer, incomplete)
+- Analysis vendor and type distribution
+- Party role patterns, unique agents, unique customers
+- Average dialogs/analysis per conversation
+- Exact count of vCons without dialog and without analysis (no sampling needed)
+
+### Step 3: Get Metadata for Subject Analysis (1 tool call)
+Use \`search_vcons\` with date filters and metadata format to extract dealership/subject patterns:
+\`\`\`json
+{
+  "start_date": "${date}T00:00:00Z",
+  "end_date": "[next day]T00:00:00Z",
+  "response_format": "metadata",
+  "limit": 200
+}
+\`\`\`
+Parse the subjects to identify dealership coverage and activity categories.
+
+### Step 4: Find Notable Conversations by Theme (2-3 tool calls)
+Use \`search_vcons_content\` with date filters to find interesting conversations by keyword:
+\`\`\`json
+{
+  "query": "test drive appointment scheduled",
+  "start_date": "${date}T00:00:00Z",
+  "end_date": "[next day]T00:00:00Z",
+  "limit": 10
+}
+\`\`\`
+Run 2-3 keyword searches for different themes:
+- Appointments/scheduling: "test drive", "appointment", "scheduled"
+- Customer issues: "complaint", "frustrated", "problem"
+- Deals/pricing: "financing", "pricing", "discount", "purchase"
+
+### Step 5: Read Summaries of Top Hits (5-10 tool calls)
+For the most interesting vCons identified in Step 4, use \`get_vcon\` with SUMMARY format:
+\`\`\`json
+{
+  "uuid": "[vcon_uuid]",
+  "response_format": "summary"
+}
+\`\`\`
+**IMPORTANT**: Use "summary" format, NOT "full". Full format loads complete transcripts (80KB+ each) which wastes context. Summary format returns only analysis summaries, which is all you need for a report.
+
+### Step 6: Synthesize the Report
+Combine:
+- **Volume**: Exact count from Step 1
+- **Content Profile**: Dialog/analysis breakdowns from Step 2
+- **Completeness**: vcons_without_dialog / vcons_without_analysis counts from Step 2 (exact numbers, not estimates)
+- **Dealership Coverage**: Subject patterns from Step 3
+- **Notable Conversations**: Specific examples from Steps 4-5
+
+### Report Structure
+1. **Volume** — Exact daily count with comparison context
+2. **Nature of Activity** — Grounded in aggregate analytics, not sample impressions
+3. **Notable Conversations** — Specific examples found via keyword search
+4. **Dealership Coverage** — Extracted from subjects
+5. **Observations** — Data-backed insights (e.g., "4,312 of 9,232 vCons (47%) had no dialog")
+
+### What NOT to Do
+- Do NOT pull random vCons and generalize from a small sample
+- Do NOT use \`get_vcon\` with "full" format for browsing — use "summary"
+- Do NOT estimate counts when exact counts are available via analytics
+- Do NOT make claims like "roughly a third" when you can compute the exact percentage
+- Do NOT fetch vCon bodies just to read the subject — use search with "metadata" format
+
+### Performance Target
+This workflow should complete in ~15 tool calls total, not dozens of full vCon fetches.
+`;
+}

--- a/src/tools/database-analytics.ts
+++ b/src/tools/database-analytics.ts
@@ -62,9 +62,10 @@ export const getDatabaseAnalyticsTool = {
 export const getMonthlyGrowthTool = {
   name: 'get_monthly_growth_analytics',
   category: 'analytics' as ToolCategory,
-  description: 'Get detailed monthly growth analytics including vCon creation trends, ' +
+  description: 'Get detailed growth analytics including vCon creation trends, ' +
     'size growth patterns, content volume changes, and growth projections. ' +
-    'Useful for capacity planning and understanding usage patterns.',
+    'Set granularity to "daily" for exact daily vCon counts (ideal for daily reports). ' +
+    'Useful for capacity planning, usage patterns, and daily activity volume.',
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -183,10 +184,22 @@ export const getContentAnalyticsTool = {
   category: 'analytics' as ToolCategory,
   description: 'Get comprehensive content analytics including dialog types, ' +
     'analysis distribution, party patterns, and conversation characteristics. ' +
-    'Provides insights into the types of conversations being stored.',
+    'Supports optional date filtering to scope analytics to a specific period (e.g. a single day). ' +
+    'For daily activity reports, use start_date/end_date to get exact counts of dialog types, ' +
+    'analysis vendors, party patterns, and vCons without dialog/analysis for just that day.',
   inputSchema: {
     type: 'object' as const,
     properties: {
+      start_date: {
+        type: 'string',
+        description: 'ISO 8601 start date to scope analytics (e.g. "2026-04-13T00:00:00Z"). ' +
+          'When set, all metrics are computed only for vCons created on or after this date.'
+      },
+      end_date: {
+        type: 'string',
+        description: 'ISO 8601 end date (exclusive) to scope analytics (e.g. "2026-04-14T00:00:00Z"). ' +
+          'When set, all metrics are computed only for vCons created before this date.'
+      },
       include_dialog_analysis: {
         type: 'boolean',
         description: 'Include dialog type and content analysis (default: true)',
@@ -204,7 +217,8 @@ export const getContentAnalyticsTool = {
       },
       include_conversation_metrics: {
         type: 'boolean',
-        description: 'Include conversation length, duration, and complexity metrics (default: true)',
+        description: 'Include conversation length, duration, and complexity metrics. ' +
+          'Includes vcons_without_dialog and vcons_without_analysis counts. (default: true)',
         default: true
       },
       include_temporal_content: {

--- a/src/tools/handlers/database-analytics.ts
+++ b/src/tools/handlers/database-analytics.ts
@@ -107,6 +107,8 @@ export class GetContentAnalyticsHandler extends BaseToolHandler {
       includePartyPatterns: args?.include_party_patterns as boolean | undefined,
       includeConversationMetrics: args?.include_conversation_metrics as boolean | undefined,
       includeTemporalContent: args?.include_temporal_content as boolean | undefined,
+      startDate: args?.start_date as string | undefined,
+      endDate: args?.end_date as string | undefined,
     };
 
     const analytics = await context.dbAnalytics.getContentAnalytics(options);

--- a/src/tools/vcon-crud.ts
+++ b/src/tools/vcon-crud.ts
@@ -181,9 +181,10 @@ export const getVConTool = {
 export const searchVConsTool = {
   name: 'search_vcons',
   category: 'read' as ToolCategory,
-  description: 'Search for vCons using various criteria including tags. Returns an array of matching vCons. ' +
+  description: 'Search for vCons using various criteria including tags, date ranges, and party info. Returns matching vCons. ' +
     'For full-text or semantic search of conversation content, use search_vcons_content instead. ' +
-    '⚠️ LARGE DATABASE WARNING: Use response_format="metadata" for large result sets to avoid memory issues.',
+    'For daily reports: use start_date/end_date with response_format="metadata" to get subjects and counts without loading bodies. ' +
+    '⚠️ LARGE DATABASE WARNING: Use response_format="metadata" or "ids_only" for large result sets to avoid memory issues.',
   inputSchema: {
     type: 'object' as const,
     properties: {


### PR DESCRIPTION
## Summary

- Add `start_date` / `end_date` parameters to `get_content_analytics` so daily reports can pull exact aggregate metrics for a single day without sampling individual vCons
- Fix `p.role` column error — the `parties` table has no `role` column; replaced `GROUP BY role` with identifier-type counts (phone/email/name)
- Add `vcons_without_dialog` and `vcons_without_analysis` counts to conversation metrics for completeness tracking
- Date-filtered queries use CTE + semi-join pattern to avoid cartesian explosion from 4-way LEFT JOIN on raw tables
- Add `daily_activity_report` prompt with a structured workflow that guides Claude through analytics-first reporting (~15 tool calls vs dozens of full vCon fetches)
- Improve tool descriptions for `search_vcons`, `get_content_analytics`, and `get_monthly_growth_analytics` to surface daily report capabilities

## Motivation

The log errors showed `column p.role does not exist` hitting repeatedly in production. Additionally, generating daily reports required manually sampling individual vCons — slow, inaccurate, and context-heavy. This PR fixes the crash and adds a purpose-built analytics workflow.

## Test plan

- [ ] Run `get_content_analytics` without date params — should return same results as before (no regression)
- [ ] Run `get_content_analytics` with `start_date` / `end_date` — should return scoped metrics
- [ ] Verify `p.role` error no longer appears in logs
- [ ] Run `daily_activity_report` prompt end-to-end in Claude Desktop
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)