### PR TITLE
fix(tags): guard getTags against non-array attachment bodies

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1086,11 +1086,17 @@ export class SupabaseVConQueries implements IVConQueries {
       return {};
     }
 
-    // Parse tags from body (array of "key:value" strings)
-    const tagsArray = JSON.parse(attachments[0].body || '[]');
+    // Parse tags from body (array of "key:value" strings). Legacy rows can
+    // hold the literal "null", "{}", or other non-array bodies — iterating
+    // those directly throws "tagsArray is not iterable", which previously
+    // surfaced from manage_tag / get_tags on vCons whose tags attachment
+    // was never populated with a proper JSON array.
+    const parsed = JSON.parse(attachments[0].body || '[]');
+    const tagsArray: unknown[] = Array.isArray(parsed) ? parsed : [];
     const tagsObject: Record<string, string> = {};
 
     for (const tagString of tagsArray) {
+      if (typeof tagString !== 'string') continue;
       const colonIndex = tagString.indexOf(':');
       if (colonIndex > 0) {
         const key = tagString.substring(0, colonIndex);

--- a/tests/db-queries.test.ts
+++ b/tests/db-queries.test.ts
@@ -407,6 +407,64 @@ describe('VConQueries', () => {
     });
   });
 
+  describe('getTags', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    // Stubs the two-query sequence getTags() runs:
+    //   1. from('vcons').select('id').eq('uuid', uuid).single()
+    //   2. from('attachments').select('body').eq('vcon_id', id).eq('type', 'tags')
+    // The 3rd `.eq(...)` call is awaited, so it must resolve with { data, error }.
+    const stubGetTagsQuery = (attachmentsBody: string | null | undefined) => {
+      mockSupabase.single.mockResolvedValueOnce({ data: { id: 1 }, error: null });
+      mockSupabase.eq
+        .mockReturnValueOnce(mockSupabase)  // .eq('uuid', uuid)
+        .mockReturnValueOnce(mockSupabase)  // .eq('vcon_id', id)
+        .mockReturnValueOnce({              // .eq('type', 'tags') — awaited
+          data: attachmentsBody === undefined
+            ? []
+            : [{ body: attachmentsBody }],
+          error: null,
+        });
+    };
+
+    it('returns {} when the vCon has no tags attachment', async () => {
+      stubGetTagsQuery(undefined);
+      const result = await queries.getTags(randomUUID());
+      expect(result).toEqual({});
+    });
+
+    it('parses a well-formed tags attachment into a key-value map', async () => {
+      stubGetTagsQuery('["department:sales","priority:high"]');
+      const result = await queries.getTags(randomUUID());
+      expect(result).toEqual({ department: 'sales', priority: 'high' });
+    });
+
+    // Regression: "tagsArray is not iterable" from manage_tag / get_tags.
+    // A tags attachment row whose body parses to a non-array (null literal,
+    // object, primitive) previously crashed the for...of loop. getTags must
+    // treat any non-array body as "no tags" so manage_tag can seed the first
+    // tag on a vCon in that state.
+    it('returns {} when the tags attachment body is the JSON literal "null"', async () => {
+      stubGetTagsQuery('null');
+      const result = await queries.getTags(randomUUID());
+      expect(result).toEqual({});
+    });
+
+    it('returns {} when the tags attachment body is an empty string', async () => {
+      stubGetTagsQuery('');
+      const result = await queries.getTags(randomUUID());
+      expect(result).toEqual({});
+    });
+
+    it('returns {} when the tags attachment body is an object, not an array', async () => {
+      stubGetTagsQuery('{"department":"sales"}');
+      const result = await queries.getTags(randomUUID());
+      expect(result).toEqual({});
+    });
+  });
+
   describe('getUniqueTags', () => {
     beforeEach(() => {
       // Reset mocks for getUniqueTags tests


### PR DESCRIPTION
## Summary
- `manage_tag` and `get_tags` both fail with `MCP error -32603: Tool execution failed: tagsArray is not iterable` whenever a vCon's `tags` attachment body parses to a non-array value — e.g. the JSON literal `null`, an object, or an empty string. `manage_tag` hits this because `addTag`/`removeTag` call `getTags` first, so the error surfaces even when trying to set the first tag on a vCon whose tags attachment was seeded with a bad body.
- Fix: in `SupabaseVConQueries.getTags()` (`src/db/queries.ts`), coerce any non-array parse result to an empty list, and skip non-string entries inside the array. This matches the defensive pattern already in place in `getUniqueTags` and the manual-scan branch of `searchByTags`.
- Regression test: new `describe('getTags')` block in `tests/db-queries.test.ts` exercising the well-formed case plus three crash shapes (`"null"`, `""`, and a JSON object body). Confirmed to fail without the fix with the exact `TypeError: tagsArray is not iterable` the user reported, and pass with it.

Reported against vCon `1025a88b-e008-480f-87c4-0fd9dee72fa8` (created as part of a Solstone-diary pipeline test on 2026-04-20).

## Test plan
- [x] `npx vitest run tests/db-queries.test.ts tests/handlers/tags.test.ts` — 47/47 pass
- [x] Stashed the fix, re-ran the new tests — two new tests fail with `TypeError: tagsArray is not iterable` at the expected line, proving the regression is reproduced
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)