### PR TITLE
docs: fix drift, broken refs, and stale tool list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,7 @@ SUPABASE_ANON_KEY=your-anon-key-here
 # Observability
 # ============================================================================
 
-# OpenTelemetry (enabled by default)
+# OpenTelemetry (enabled by default; set OTEL_ENABLED=false to disable)
 # OTEL_ENABLED=true
 # OTEL_EXPORTER_TYPE=console
 # OTEL_ENDPOINT=http://localhost:4318

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,17 @@ Format: `"key:value"` strings in a JSON array.
 | `search_by_tags` | Find vCons by tag values |
 | `get_unique_tags` | Discover available tags |
 
+### Analytics Tools
+
+| Tool | Description |
+|------|-------------|
+| `get_database_analytics` | Size, growth trends, content distribution |
+| `get_monthly_growth_analytics` | Monthly growth patterns and projections |
+| `get_attachment_analytics` | Attachment types, sizes, storage |
+| `get_tag_analytics` | Tag usage patterns and value distribution |
+| `get_content_analytics` | Dialog types, party patterns, content insights |
+| `get_database_health_metrics` | Performance and optimization recommendations |
+
 ### Database Tools
 
 | Tool | Description |
@@ -148,6 +159,8 @@ Format: `"key:value"` strings in a JSON array.
 | `get_database_shape` | Tables, indexes, sizes |
 | `get_database_stats` | Performance statistics |
 | `analyze_query` | Query execution plan |
+| `get_database_size_info` | Size info and smart recommendations for large datasets |
+| `get_smart_search_limits` | Recommended limits to prevent memory issues |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A Model Context Protocol (MCP) server for storing, managing, and analyzing IETF vCon (Virtual Conversation) data with AI assistants.
 
-![Version](https://img.shields.io/badge/version-1.0.1-blue)
+![Version](https://img.shields.io/npm/v/vcon-mcp?label=version)
 ![IETF Spec](https://img.shields.io/badge/IETF%20vCon-draft--02%20v0.4.0-green)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 
@@ -49,7 +49,7 @@ The Model Context Protocol (MCP) enables AI assistants to use external tools and
   - Hybrid search (combines keyword and semantic)
 - ✅ **Tag Filtering** - Filter search results by tags via `attachments` of type `tags`
 - ✅ **Content Indexing** - Searches dialog bodies and analysis content (encoding='none')
-- ✅ **Real-time** - Supabase realtime subscriptions for live updates
+- ✅ **Real-time-ready** - Supabase realtime subscriptions are available at the database layer (not yet exposed via MCP tools)
 - ✅ **Conserver Integration** - Compatible with vCon conserver for chain processing
 
 ## Quick Start
@@ -106,6 +106,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ```
 
 **Note**: `REDIS_URL` is optional. If provided, enables high-performance caching for 20-50x faster reads. See [Redis-Supabase Integration Guide](docs/guide/redis-supabase-integration.md).
+
+**Database backend**: Defaults to Supabase (`DB_TYPE=supabase`). MongoDB is also supported via `DB_TYPE=mongodb` — see [docs/mongodb/setup.md](docs/mongodb/setup.md).
 
 Restart Claude Desktop and start using vCon tools!
 
@@ -248,11 +250,8 @@ npm run db:restore
 ### Embeddings Management
 
 ```bash
-# Backfill missing embeddings
-npm run embeddings:backfill
-
-# Generate embeddings locally
-npm run embeddings:generate
+# Continuously generate embeddings for vCons missing them
+npm run sync:embeddings
 
 # Check embedding coverage
 npm run embeddings:check
@@ -378,6 +377,8 @@ See [MCP Streamable HTTP Specification](https://modelcontextprotocol.io/specific
 
 When running in HTTP transport mode, the server exposes a full RESTful HTTP API with parity to all MCP tools. Both interfaces share the same `VConService` business logic, plugin hooks, and database queries.
 
+> **Path layout:** the MCP HTTP endpoint is mounted at `/` (root), and the REST API is mounted at `REST_API_BASE_PATH` (default `/api/v1`). They share the same port — that's why the curl examples above hit `/` for MCP but `/api/v1/...` for REST.
+
 ### Endpoints (30+)
 
 | Category | Endpoints | Description |
@@ -426,195 +427,67 @@ See the complete [REST API Reference](docs/api/rest-api.md) for detailed documen
 
 ## Available MCP Tools
 
-### 1. **create_vcon**
-
-Create a new vCon with parties and optional initial data.
-
-```
-Create a vCon for a customer support call between Alice and Bob
-```
-
-### 2. **get_vcon**
-
-Retrieve a complete vCon by UUID.
-
-```
-Get the vCon with UUID abc-123-def
-```
-
-### 3. **search_vcons**
-
-Search vCons by subject, party name, or date range (basic filtering).
-
-```
-Find all vCons from last week about billing
-```
-
-### 3a. **search_vcons_content**
-
-Full-text keyword search across dialog, analysis, and party content.
-
-```
-Search for conversations mentioning "refund request"
-```
-
-### 3b. **search_vcons_semantic**
-
-AI-powered semantic search to find conversations by meaning (requires embeddings).
-
-```
-Find conversations where customers were frustrated with delivery times
-```
-
-### 3c. **search_vcons_hybrid**
-
-Combined keyword and semantic search for comprehensive results.
-
-```
-Search for billing disputes using both exact matches and similar concepts
-```
-
-### 4. **add_analysis**
-
-Add AI/ML analysis results to a vCon.
-
-```
-Add sentiment analysis showing positive sentiment to vCon abc-123
-```
-
-### 5. **add_dialog**
-
-Add a conversation segment (recording, text, video, etc.).
-
-```
-Add a text dialog from Alice saying "Hello, how can I help you?"
-```
-
-### 6. **add_attachment**
-
-Attach files, documents, or supporting materials.
-
-```
-Attach the customer's invoice PDF to this vCon
-```
-
-### 7. **delete_vcon**
-
-Delete a vCon and all related data.
-
-```
-Delete the vCon abc-123
-```
-
-### 8. **get_database_analytics**
-
-Get comprehensive database analytics including size, growth trends, and content distribution.
-
-```
-Get database analytics for the last 6 months
-```
-
-### 9. **get_monthly_growth_analytics**
-
-Get detailed monthly growth patterns and projections.
-
-```
-Show me monthly growth trends for the past year
-```
-
-### 10. **get_attachment_analytics**
-
-Analyze attachment types, sizes, and storage patterns.
-
-```
-What types of files are being stored and how much space do they use?
-```
-
-### 11. **get_tag_analytics**
-
-Analyze tag usage patterns and value distribution.
-
-```
-Show me the most commonly used tags and their values
-```
-
-### 12. **get_content_analytics**
-
-Get insights into conversation content, dialog types, and party patterns.
-
-```
-Analyze the types of conversations and content being stored
-```
-
-### 13. **get_database_health_metrics**
-
-Monitor database performance and get optimization recommendations.
-
-```
-Check database health and performance metrics
-```
-
-### 14. **get_database_size_info**
-
-Get database size information and smart recommendations for large datasets.
-
-```
-Get database size info and recommendations for query limits
-```
-
-### 15. **get_smart_search_limits**
-
-Get smart search limits based on database size to prevent memory issues.
-
-```
-Get recommended limits for content search on this large database
-```
-
-### 16. **update_vcon**
-
-Update top-level vCon metadata (subject, extensions, must_support).
-
-```
-Update vCon 01f3-... with subject "Updated Subject"
-```
-
-### 9. **create_vcon_from_template**
-
-Create a new vCon from a predefined template (phone_call, chat_conversation, email_thread, video_meeting, custom).
-
-```
-Create a phone_call vCon with two parties and subject "Onboarding"
-```
-
-### 10. **get_schema**
-
-Get vCon schema (json_schema or typescript).
-
-```
-Get the vCon JSON Schema
-```
-
-### 11. **get_examples**
-
-Get example vCons (minimal, phone_call, chat, email, video, full_featured) in JSON or YAML.
-
-## Database Inspection Tools
-
-### 12. **get_database_shape**
-
-Get comprehensive database structure information including tables, indexes, sizes, and relationships. Useful for debugging and understanding your database schema.
-
-### 13. **get_database_stats**
-
-Get database performance and usage statistics including cache hit ratios, table access patterns, and index usage. Essential for performance monitoring and optimization.
-
-### 14. **analyze_query**
-
-Analyze SQL query execution plans for performance optimization (limited support).
-
-```
-Show a minimal example vCon as JSON
-```
+The server exposes 30 MCP tools, grouped by purpose. See [docs/api/tools.md](docs/api/tools.md) for full schemas.
+
+### CRUD
+
+| Tool | Description |
+|------|-------------|
+| `create_vcon` | Create a new vCon with parties and optional initial data |
+| `create_vcon_from_template` | Create a vCon from a template (phone_call, chat_conversation, email_thread, video_meeting, custom) |
+| `get_vcon` | Retrieve a complete vCon by UUID |
+| `update_vcon` | Update top-level vCon metadata (subject, extensions, critical) |
+| `delete_vcon` | Delete a vCon and all related data |
+| `add_dialog` | Add a conversation segment (recording, text, transfer, incomplete) |
+| `add_analysis` | Add AI/ML analysis results (vendor required) |
+| `add_attachment` | Attach files, documents, or supporting materials |
+
+### Search
+
+| Tool | Description |
+|------|-------------|
+| `search_vcons` | Filter by subject, party, date range |
+| `search_vcons_content` | Full-text keyword search across dialog, analysis, parties |
+| `search_vcons_semantic` | AI embedding similarity search (requires embeddings) |
+| `search_vcons_hybrid` | Combined keyword + semantic |
+
+### Tags
+
+| Tool | Description |
+|------|-------------|
+| `manage_tag` | Add, update, or remove a single tag |
+| `get_tags` | Get one or all tags for a vCon |
+| `remove_all_tags` | Clear all tags from a vCon |
+| `search_by_tags` | Find vCons by tag values |
+| `get_unique_tags` | Discover available tag keys/values |
+
+### Analytics
+
+| Tool | Description |
+|------|-------------|
+| `get_database_analytics` | Size, growth trends, content distribution |
+| `get_monthly_growth_analytics` | Monthly growth patterns and projections |
+| `get_attachment_analytics` | Attachment types, sizes, storage patterns |
+| `get_tag_analytics` | Tag usage patterns and value distribution |
+| `get_content_analytics` | Dialog types, party patterns, content insights |
+| `get_database_health_metrics` | Performance and optimization recommendations |
+
+### Schema & Examples
+
+| Tool | Description |
+|------|-------------|
+| `get_schema` | Get vCon schema (json_schema or typescript) |
+| `get_examples` | Get example vCons (minimal, phone_call, chat, email, video, full_featured) |
+
+### Database Inspection
+
+| Tool | Description |
+|------|-------------|
+| `get_database_shape` | Tables, indexes, sizes, relationships |
+| `get_database_stats` | Cache hit ratios, table access, index usage |
+| `analyze_query` | SQL query execution plan analysis (limited support) |
+| `get_database_size_info` | Size info and smart recommendations for large datasets |
+| `get_smart_search_limits` | Recommended search limits to prevent memory issues |
 
 ## Tool Categories & Configuration
 
@@ -857,34 +730,7 @@ See [Observability Guide](docs/guide/observability.md) for complete documentatio
 
 ## Project Structure
 
-```
-vcon-mcp/
-├── src/
-│   ├── index.ts              # MCP server entry point
-│   ├── types/
-│   │   └── vcon.ts          # IETF vCon type definitions
-│   ├── db/
-│   │   ├── client.ts        # Supabase client
-│   │   └── queries.ts       # Database operations
-│   ├── tools/
-│   │   └── vcon-crud.ts     # MCP tool definitions
-│   └── utils/
-│       └── validation.ts    # vCon validation
-├── supabase/
-│   └── migrations/          # Database migrations
-├── tests/
-│   └── vcon-compliance.test.ts
-├── docs/
-│   └── reference/           # Technical reference docs
-│       ├── QUICK_REFERENCE.md
-│       ├── IMPLEMENTATION_CORRECTIONS.md
-│       ├── CORRECTED_SCHEMA.md
-│       └── MIGRATION_GUIDE.md
-├── background_docs/         # IETF specs & references
-├── CLAUDE.md               # AI coding agent instructions
-├── DOCUMENTATION_GUIDE.md  # Documentation system guide
-└── README.md               # This file
-```
+For the authoritative source layout (including `src/api/`, `src/server/`, `src/services/`, `src/prompts/`, `src/hooks/` and the route/handler split), see the **File Structure** section in [CLAUDE.md](CLAUDE.md). That document is kept in sync with the code; this README intentionally does not duplicate the tree.
 
 ## Documentation
 
@@ -927,7 +773,8 @@ vcon-mcp/
 
 ### IETF Specifications
 
-- **[IETF vCon Core Spec](background_docs/draft-ietf-vcon-vcon-core-00.txt)** - Official specification
+- **[IETF vCon Core Spec (-00, in repo)](background_docs/draft-ietf-vcon-vcon-core-00.txt)** - v0.3.0 baseline shipped with this repo
+- **[IETF vCon Core Spec (current draft)](https://datatracker.ietf.org/doc/draft-ietf-vcon-vcon-core/)** - Latest `-02` (v0.4.0) on the IETF datatracker
 - **[vCon Consent Draft](background_docs/draft-howe-vcon-consent-00.txt)** - Privacy and consent
 - **[vCon Lifecycle Draft](background_docs/draft-howe-vcon-lifecycle-00.txt)** - Lifecycle management
 - **[vCon Quick Start](background_docs/vcon_quickstart_guide.md)** - vCon basics
@@ -994,7 +841,7 @@ See [RLS Multi-Tenant Guide](docs/guide/rls-multi-tenant.md) for enabling multi-
 
 ## IETF vCon Specification Compliance
 
-This implementation is fully compliant with `draft-ietf-vcon-vcon-core-00`, including:
+This implementation targets `draft-ietf-vcon-vcon-core-02` (vCon v0.4.0), including:
 
 ### Core Objects
 
@@ -1153,7 +1000,7 @@ export async function handleGetAnalytics(input: any): Promise<ToolResponse> {
 ### Quick Start: Create a Plugin
 
 ```typescript
-import { VConPlugin, RequestContext } from '@vcon/mcp-server/hooks';
+import { VConPlugin, RequestContext } from 'vcon-mcp/hooks';
 
 export default class MyPlugin implements VConPlugin {
   name = 'my-plugin';
@@ -1235,10 +1082,9 @@ MIT License - see [LICENSE](LICENSE) file for details
 
 ## Support
 
-- 📧 **Email**: ohjesus@doesanyoneemail.anymore
-- 💬 **Discord**: [Join our community](https://discord.gg/example)
-- 📖 **Documentation**: [Full docs](https://docs.example.com)
 - 🐛 **Bug Reports**: [GitHub Issues](https://github.com/vcon-dev/vcon-mcp/issues)
+- 💬 **Discussions**: [GitHub Discussions](https://github.com/vcon-dev/vcon-mcp/discussions)
+- 📖 **Documentation**: [mcp.conserver.io](https://mcp.conserver.io/)
 
 ## Acknowledgments
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,15 +74,15 @@ features:
 ::: code-group
 
 ```bash [npm]
-npm install @vcon/mcp-server
+npm install vcon-mcp
 ```
 
 ```bash [yarn]
-yarn add @vcon/mcp-server
+yarn add vcon-mcp
 ```
 
 ```bash [pnpm]
-pnpm add @vcon/mcp-server
+pnpm add vcon-mcp
 ```
 
 :::
@@ -105,7 +105,7 @@ The Model Context Protocol (MCP) enables AI assistants to use external tools and
 
 ### Core Capabilities
 
-- ✅ **15+ MCP Tools** - Complete CRUD operations, search, tagging, templates
+- ✅ **30 MCP Tools** - Complete CRUD operations, search, tagging, templates, analytics
 - ✅ **9 Query Prompts** - Guide AI assistants to search effectively
 - ✅ **4 Search Modes** - Basic, keyword, semantic, and hybrid search
 - ✅ **Tag System** - Flexible key-value metadata for organization
@@ -178,7 +178,7 @@ Then ask Claude:
 ### Programmatic Usage
 
 ```typescript
-import { VConQueries } from '@vcon/mcp-server';
+import { VConQueries } from 'vcon-mcp';
 import { createClient } from '@supabase/supabase-js';
 
 const supabase = createClient(url, key);

--- a/docs/reference/QUICK_REFERENCE.md
+++ b/docs/reference/QUICK_REFERENCE.md
@@ -242,7 +242,7 @@ const party: Party = {
 // This should compile without errors
 const dialog: Dialog = {
   type: 'recording',
-  session_id: 'session-123',
+  session_id: { local: 'session-local-123', remote: 'session-remote-123' },
   application: 'TestApp'
 };
 
@@ -268,7 +268,8 @@ const wrongAnalysis2: Analysis = {
 - Full instructions: `CLAUDE.md`
 - Detailed corrections: `IMPLEMENTATION_CORRECTIONS.md`
 - Database schema: `CORRECTED_SCHEMA.md`
-- IETF spec: `background_docs/draft-ietf-vcon-vcon-core-02.txt`
+- IETF spec (in repo, v0.3.0 baseline): `background_docs/draft-ietf-vcon-vcon-core-00.txt`
+- IETF spec (current draft -02 / v0.4.0): https://datatracker.ietf.org/doc/draft-ietf-vcon-vcon-core/
 
 ---
 
@@ -310,7 +311,7 @@ grep -r "vendor\?" src/types/
 **Then verify against:**
 - `CLAUDE.md` - Section matching your task
 - `IMPLEMENTATION_CORRECTIONS.md` - List of all corrections
-- `draft-ietf-vcon-vcon-core-02.txt` - The authoritative spec
+- `background_docs/draft-ietf-vcon-vcon-core-00.txt` (in repo) — and the current `-02` draft on the IETF datatracker for the authoritative spec
 
 ---
 


### PR DESCRIPTION
## Summary

Audit-driven cleanup of the user-facing docs surface (README, docs landing page, CLAUDE.md, QUICK_REFERENCE, .env.example). Fixes 16 issues found in a `/doc-review` pass — version drift, broken spec links, wrong package name, placeholder contact info, a broken duplicate-numbered MCP tool list, missing MongoDB coverage, stale project tree, and references to npm scripts that don't exist.

## What changed

**README.md**
- Version badge → live `npm/v/vcon-mcp` (was hard-coded `1.0.1`; package is `1.2.0`)
- Reconciled spec references to `draft-02` / `v0.4.0` throughout (one section claimed `-00`)
- Fixed package name in install + import snippets: `vcon-mcp` not `@vcon/mcp-server`
- Replaced placeholder support block (`ohjesus@doesanyoneemail.anymore`, `discord.gg/example`, `docs.example.com`) with real GitHub Issues/Discussions links
- Replaced broken duplicate-numbered tool prose (had two `### 9.`, `### 10.`, etc.) with a flat grouped table covering all 30 tools
- Added MongoDB backend note (the option exists in `.env.example` and `docs/mongodb/` but was invisible from the README)
- Added one-sentence REST/MCP path-layout note explaining why curl examples use different paths
- Clarified realtime as DB-layer-only (feature list previously implied MCP exposure)
- Removed references to non-existent `embeddings:backfill` / `embeddings:generate` scripts
- Replaced stale project-tree with a pointer to CLAUDE.md (which is kept in sync with code)
- `must_support` → `critical` in `update_vcon` description (renamed in v0.4.0)

**docs/index.md**
- Install snippets and import use `vcon-mcp`
- Tool count reconciled to `30 MCP Tools` (was `15+`)

**docs/reference/QUICK_REFERENCE.md**
- `session_id` test example now matches the v0.4.0 `{ local, remote }` object shape the same file documents (was `'session-123'`)
- Spec links point at the in-repo `-00.txt` plus the IETF datatracker for the current `-02`

**CLAUDE.md**
- Added Analytics Tools section (`get_database_analytics`, `get_monthly_growth_analytics`, `get_attachment_analytics`, `get_tag_analytics`, `get_content_analytics`, `get_database_health_metrics`)
- Added missing DB-size tools (`get_database_size_info`, `get_smart_search_limits`)

**.env.example**
- Clarified that `OTEL_ENABLED` defaults to `true` even when the line is commented out (verified: `src/observability/config.ts:67` defaults `!== 'false'`)

## Notes for reviewers

- No code changes — docs only. Net `-140` lines, almost all from collapsing the duplicate-numbered tool list.
- Tool count of 30 was verified against `src/tools/*.ts`.
- Verification: `grep -rn "@vcon/mcp-server" README.md docs/ CLAUDE.md` returns 0; only the legitimate in-repo link to `draft-ietf-vcon-vcon-core-00.txt` remains.

## Test plan

- [ ] Render `npm run docs:dev` and skim landing page + reference pages for layout regressions
- [ ] Confirm npm version badge resolves on GitHub
- [ ] Spot-check at least one link in each modified doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)