### PR TITLE
Harden vcon_search for LLMs + discovery/shape-graph surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Model Context Protocol (MCP) enables AI assistants to use external tools and
 - ✅ **IETF vCon Compliant** - Implements `draft-ietf-vcon-vcon-core-02` specification (v0.4.0)
 - ✅ **MCP Integration** - 35 tools for AI assistants to manage conversation data
 - ✅ **Redesigned Contract Tools** - Additive `vcon_fetch`, `vcon_capabilities`, `vcon_search`, `vcon_taxonomy`, and `describe_response_shape` tools for predictable envelopes, explicit payload control, and discovery-first clients
-- ✅ **REST API** - Full HTTP REST API with parity to all MCP tools (CRUD, search, tags, analytics)
+- ✅ **REST API** - Full HTTP REST API with CRUD, discovery, filtered reads, search, tags, and analytics surfaces
 - ✅ **Database Analytics** - Comprehensive analytics for size, growth, content patterns, and health monitoring
 - ✅ **Large Database Support** - Smart response limiting, metadata-only options, and memory-safe queries
 - ✅ **OpenTelemetry Observability** - Full traces, metrics, and structured logs with console or OTLP export
@@ -386,7 +386,8 @@ When running in HTTP transport mode, the server exposes a full RESTful HTTP API 
 |----------|-----------|-------------|
 | **CRUD** | `POST/GET/PATCH/DELETE /vcons` | Create, read, update, delete vCons |
 | **Batch** | `POST /vcons/batch` | Batch ingest up to 100 vCons |
-| **Sub-resources** | `POST /vcons/:uuid/{dialog,analysis,attachments}` | Append dialog, analysis, attachments |
+| **Sub-resources** | `GET/POST /vcons/:uuid/{analysis,attachments}` and `POST /vcons/:uuid/dialog` | Read or append analysis and attachments, append dialog |
+| **Discovery** | `GET /discovery/attachments/{purposes,types}`, `GET /discovery/analysis/types` | Discover live categories, with attachment purposes as the canonical spec surface |
 | **Tags** | `GET/PUT/DELETE /vcons/:uuid/tags` | Per-vCon tag management |
 | **Tag Discovery** | `GET /tags`, `GET /tags/search` | Discover and search by tags |
 | **Search** | `GET /vcons/search/{content,semantic,hybrid}` | Keyword, semantic, and hybrid search |
@@ -422,7 +423,17 @@ curl -X POST http://localhost:3000/api/v1/vcons \
 # Search by keyword
 curl "http://localhost:3000/api/v1/vcons/search/content?q=billing+issue" \
   -H "Authorization: Bearer your-api-key"
+
+# Discover attachment purposes before reading by category
+curl "http://localhost:3000/api/v1/discovery/attachments/purposes" \
+  -H "Authorization: Bearer your-api-key"
+
+# Read only dealer-info attachments for one vCon
+curl "http://localhost:3000/api/v1/vcons/123e4567-e89b-12d3-a456-426614174000/attachments?purpose=dealer_info" \
+  -H "Authorization: Bearer your-api-key"
 ```
+
+When a classification lives in attachments or analysis, discover the live values first and read through those filtered surfaces. For attachments, prefer `purpose` because it is the spec field; use attachment `type` only as a legacy compatibility fallback. Use tags when the classification genuinely lives in the tags attachment.
 
 See the complete [REST API Reference](docs/api/rest-api.md) for detailed documentation.
 
@@ -588,15 +599,23 @@ MCP_DISABLED_TOOLS=delete_vcon,analyze_query
 
 The server exposes URI-based resources for direct reads:
 
+- `vcon://v1/discovery/attachments/purposes` – discovered attachment purposes with counts
+- `vcon://v1/discovery/attachments/types` – discovered legacy attachment types with counts
+- `vcon://v1/discovery/analysis/types` – discovered analysis types with counts
 - `vcon://v1/vcons/{uuid}` – full vCon JSON
 - `vcon://v1/vcons/{uuid}/metadata` – metadata only
 - `vcon://v1/vcons/{uuid}/parties` – parties array
 - `vcon://v1/vcons/{uuid}/dialog` – dialog array
 - `vcon://v1/vcons/{uuid}/attachments` – attachments array
+- `vcon://v1/vcons/{uuid}/attachments/purpose/{purpose}` – attachments filtered by purpose
+- `vcon://v1/vcons/{uuid}/attachments/type/{type}` – attachments filtered by legacy type
 - `vcon://v1/vcons/{uuid}/analysis` – analysis array
+- `vcon://v1/vcons/{uuid}/analysis/type/{type}` – analysis filtered by type
 - `vcon://v1/vcons/{uuid}/transcript` – transcript analysis (filtered)
 - `vcon://v1/vcons/{uuid}/summary` – summary analysis (filtered)
 - `vcon://v1/vcons/{uuid}/tags` – tags as object (parsed)
+
+For attachment- or analysis-backed classifications, start with the discovery resources and then read the matching filtered surface. For attachments, prefer `purpose`; use `type` only for compatibility with older datasets. Prefer tags only when the data is actually stored as tags.
 
 ## Use Cases
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -61,5 +61,11 @@
 ## Examples
 
 * [Overview](examples/index.md)
+* [System Instruction Assets](examples/system-instruction-assets.md)
 * [Large Database Optimization](examples/large-database-optimization.md)
+
+## Optimization
+
+* [Thread context bootstrap](optimization/thread-context-bootstrap.md)
+* [Session handoff for vault](optimization/SESSION_HANDOFF_FOR_VAULT.md)
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -17,7 +17,8 @@ For new MCP clients, start with the redesigned contract surface: `vcon_capabilit
 Full HTTP REST API with parity to all MCP tools (30+ endpoints):
 
 - **vCon CRUD** - Create, read, update, delete + batch ingest
-- **Sub-resources** - Append dialog, analysis, attachments
+- **Discovery + Filtered Reads** - Discover live categories, then read by attachment `purpose` or analysis `type`
+- **Sub-resources** - Read or append analysis and attachments, append dialog
 - **Tags** - Per-vCon tag management + tag discovery
 - **Search** - Keyword, semantic, and hybrid search
 - **Database** - Schema shape, stats, size, health monitoring
@@ -48,11 +49,17 @@ Full HTTP REST API with parity to all MCP tools (30+ endpoints):
 
 URI-based access to vCon data:
 
+- `vcon://v1/discovery/attachments/purposes` - Discover live attachment purposes
+- `vcon://v1/discovery/attachments/types` - Discover legacy attachment types
+- `vcon://v1/discovery/analysis/types` - Discover live analysis types
 - `vcon://v1/vcons/recent` - Get recent vCons
 - `vcon://v1/vcons/recent/ids` - Lightweight ID lists
 - `vcon://v1/vcons/ids` - Paginated ID browsing
 - `vcon://v1/vcons/{uuid}` - Get specific vCon
 - `vcon://v1/vcons/{uuid}/metadata` - Get metadata only
+- `vcon://v1/vcons/{uuid}/attachments/purpose/{purpose}` - Read attachments by purpose
+- `vcon://v1/vcons/{uuid}/attachments/type/{type}` - Read attachments by legacy type
+- `vcon://v1/vcons/{uuid}/analysis/type/{type}` - Read analysis by type
 
 [View Resources Reference →](./resources.md)
 
@@ -160,6 +167,14 @@ const recent = await readResource("vcon://v1/vcons/recent/10");
 // Get specific vCon
 const vcon = await readResource(
   "vcon://v1/vcons/123e4567-e89b-12d3-a456-426614174000"
+);
+
+// Discover live attachment purposes first
+const purposes = await readResource("vcon://v1/discovery/attachments/purposes");
+
+// Then read a specific category-backed view
+const dealerInfo = await readResource(
+  "vcon://v1/vcons/123e4567-e89b-12d3-a456-426614174000/attachments/purpose/dealer_info"
 );
 
 // List IDs for navigation

--- a/docs/api/resources.md
+++ b/docs/api/resources.md
@@ -4,27 +4,34 @@ Resources provide URI-based access to vCon data through the Model Context Protoc
 
 ## Overview
 
-Resources use a versioned URI scheme (`vcon://v1/vcons/...`) to access vCon data:
+Resources use versioned URI schemes to access vCon data:
 
 - **Browsing** - List recent conversations
 - **Lookup** - Fetch specific vCons by UUID
-- **Discovery** - Get lightweight ID lists for navigation
+- **Discovery** - Get lightweight ID lists and live attachment or analysis categories
 - **Subresources** - Access specific vCon components (parties, dialog, analysis, attachments)
-- **Derived** - Get filtered data (transcripts, summaries, tags)
+- **Derived** - Get filtered data (transcripts, summaries, tags, and generic category-backed reads)
 
-For complex operations like filtering, searching, and modifications, use [MCP Tools](./tools.md) instead.
+For complex searches and modifications, use [MCP Tools](./tools.md) instead.
 
 ---
 
 ## Resource Namespace
 
-All resources use the versioned namespace:
+All resources use versioned namespaces:
 
 ```
+vcon://v1/discovery/...
 vcon://v1/vcons/...
 ```
 
 This allows for future schema evolution without breaking existing clients.
+
+When a classification lives in attachments or analysis, prefer this flow:
+
+1. Discover available `type` or `purpose` values.
+2. Read the matching filtered resource for a specific vCon.
+3. Fall back to tags only when the classification really lives in the tags attachment.
 
 ---
 
@@ -222,7 +229,7 @@ Get only metadata fields, excluding conversation content arrays.
   "updated_at": "2025-10-14T11:00:00Z",
   "subject": "Customer Support Call",
   "extensions": [],
-  "must_support": []
+  "critical": []
 }
 ```
 
@@ -380,9 +387,105 @@ Get only the attachments array from a vCon.
 
 ---
 
+## Discovery Resources
+
+Use these resources to discover live attachment and analysis categories before reading a specific vCon by the matching field. For attachments, `purpose` is canonical and `type` is compatibility-only.
+
+### vcon://v1/discovery/attachments/types
+
+List discovered legacy attachment `type` values with counts.
+
+Use this only when you are working with older datasets that still classify attachments through `type`. For spec-facing clients, prefer `vcon://v1/discovery/attachments/purposes`.
+
+**Response:**
+
+```json
+{
+  "count": 2,
+  "attachment_types": [
+    { "value": "document", "count": 14 },
+    { "value": "tags", "count": 8 }
+  ]
+}
+```
+
+### vcon://v1/discovery/attachments/purposes
+
+List discovered attachment `purpose` values with counts.
+
+This is the canonical spec-facing attachment discovery surface.
+
+**Response:**
+
+```json
+{
+  "count": 2,
+  "attachment_purposes": [
+    { "value": "dealer_info", "count": 5 },
+    { "value": "classification", "count": 3 }
+  ]
+}
+```
+
+### vcon://v1/discovery/analysis/types
+
+List discovered analysis `type` values with counts.
+
+**Response:**
+
+```json
+{
+  "count": 2,
+  "analysis_types": [
+    { "value": "summary", "count": 11 },
+    { "value": "transcript", "count": 9 }
+  ]
+}
+```
+
+---
+
+## Generic Filtered Resources
+
+These resources expose attachment and analysis categories as first-class read surfaces instead of requiring special-case resource definitions.
+
+### vcon://v1/vcons/{uuid}/attachments/type/{type}
+
+Read attachments filtered by legacy attachment `type`.
+
+Use this only for compatibility with older data. New clients should prefer the purpose-based resource below.
+
+### vcon://v1/vcons/{uuid}/attachments/purpose/{purpose}
+
+Read attachments filtered by attachment `purpose`.
+
+This is the canonical spec-facing attachment read path.
+
+### vcon://v1/vcons/{uuid}/analysis/type/{type}
+
+Read analysis filtered by analysis `type`.
+
+**Example response:**
+
+```json
+{
+  "count": 1,
+  "purpose": "dealer_info",
+  "attachments": [
+    {
+      "type": "document",
+      "purpose": "dealer_info",
+      "filename": "dealer.json"
+    }
+  ]
+}
+```
+
+---
+
 ## Derived Resources
 
-These resources filter and transform vCon data for specific use cases.
+These resources filter and transform vCon data for specific use cases. Internally they follow the same shared filtering path as the generic category-backed resources.
 
 ### vcon://v1/vcons/{uuid}/transcript
 
@@ -482,7 +585,7 @@ Get tags from a vCon (filters attachments where type='tags' and parses as object
 
 ✅ **Browsing** - Viewing recent or all vCons  
 ✅ **Lookup** - Fetching specific vCon by UUID  
-✅ **Simple** - No filtering or complex queries  
+✅ **Simple** - Browsing, lookup, and category-backed reads after discovery  
 ✅ **Read-only** - Just retrieving data  
 ✅ **Subcomponents** - Accessing specific vCon arrays  
 
@@ -510,6 +613,14 @@ const vcon = await readResource("vcon://v1/vcons/123e4567-e89b-12d3-a456-4266141
 
 // Get just parties
 const parties = await readResource("vcon://v1/vcons/123e4567-e89b-12d3-a456-426614174000/parties");
+
+// Discover live attachment purposes
+const purposes = await readResource("vcon://v1/discovery/attachments/purposes");
+
+// Read only dealer info attachments
+const dealerInfo = await readResource(
+  "vcon://v1/vcons/123e4567-e89b-12d3-a456-426614174000/attachments/purpose/dealer_info"
+);
 
 // Get summary
 const summary = await readResource("vcon://v1/vcons/123e4567-e89b-12d3-a456-426614174000/summary");

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -13,6 +13,7 @@ The vCon MCP Server exposes a RESTful HTTP API alongside the MCP transport layer
 - **CORS Support** - Configurable cross-origin resource sharing
 - **Plugin Integration** - Full lifecycle hooks (beforeCreate, afterCreate, etc.)
 - **Batch Operations** - Ingest up to 100 vCons in a single request
+- **Discovery-Backed Reads** - Discover live attachment and analysis categories, then read by `type` or `purpose`
 - **Health Checks** - Built-in health endpoint for monitoring
 
 ---
@@ -113,6 +114,32 @@ You can use a different header by setting `API_KEY_HEADER` (e.g. `x-api-key`).
 ---
 
 ## Endpoints
+
+### Discovery-First Reads
+
+When a classification is stored in attachments or analysis, prefer this sequence:
+
+1. Discover available values first. For attachments, prefer `purpose`; use attachment `type` only for legacy compatibility. For analysis, use `type`.
+2. Read the matching filtered vCon subresource.
+3. Use tags when the classification genuinely lives in the tags attachment.
+
+Examples:
+
+```bash
+# Discover live attachment purposes
+curl "http://localhost:3000/api/v1/discovery/attachments/purposes" \
+  -H "Authorization: Bearer your-api-key"
+
+# Read one vCon's dealer info attachments
+curl "http://localhost:3000/api/v1/vcons/123e4567-e89b-12d3-a456-426614174000/attachments?purpose=dealer_info" \
+  -H "Authorization: Bearer your-api-key"
+
+# Read one vCon's summary analysis through the generic type filter
+curl "http://localhost:3000/api/v1/vcons/123e4567-e89b-12d3-a456-426614174000/analysis?type=summary" \
+  -H "Authorization: Bearer your-api-key"
+```
+
+---
 
 ### Health Check
 
@@ -760,11 +787,21 @@ The REST API now has full parity with MCP tools. All endpoints use `/api/v1` as 
 | POST | `/vcons/batch` | Batch create (up to 100) |
 | GET | `/vcons` | List/search vCons (filter with query params) |
 | GET | `/vcons/:uuid` | Get vCon by UUID (`?format=full\|summary\|metadata`) |
+| GET | `/vcons/:uuid/analysis` | Read analysis, optionally filtered by `?type=` |
+| GET | `/vcons/:uuid/attachments` | Read attachments, preferably filtered by `?purpose=`; `?type=` remains for legacy compatibility |
 | PATCH | `/vcons/:uuid` | Update vCon metadata (subject, extensions, critical) |
 | DELETE | `/vcons/:uuid` | Delete a vCon |
 | POST | `/vcons/:uuid/dialog` | Add dialog to a vCon |
 | POST | `/vcons/:uuid/analysis` | Add analysis to a vCon |
 | POST | `/vcons/:uuid/attachments` | Add attachment to a vCon |
+
+### Discovery
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/discovery/attachments/purposes` | Discover live attachment purposes (`?include_counts=false`, `?min_count=2`) |
+| GET | `/discovery/attachments/types` | Discover legacy attachment types (`?include_counts=false`, `?min_count=2`) |
+| GET | `/discovery/analysis/types` | Discover live analysis types (`?include_counts=false`, `?min_count=2`) |
 
 ### Tags
 

--- a/docs/api/shape-graph-and-plugins.md
+++ b/docs/api/shape-graph-and-plugins.md
@@ -1,0 +1,30 @@
+# Shape graph (OSS) and custom graphs via plugins
+
+## Default shape graph
+
+The open source server exposes a **corpus-level shape graph**: which `analysis.type` values, `attachments.purpose` values, legacy `attachments.type` values (when purpose is absent), and tag keys appear in stored vCons, plus optional **co-occurrence** edges (same vCon carries both an analysis type and an attachment purpose). Counts are aggregates over the tenant-scoped database; see `corpus.notes` in the payload for backend-specific semantics.
+
+**Surfaces**
+
+- MCP resource: `vcon://v1/graph/shape` (JSON body matches the tool payload).
+- Read-only tool: `vcon_graph_shape` (same JSON for clients that do not use resources first).
+
+**Discovery order**
+
+1. `vcon_capabilities` (limits, modes, and pointers to the shape graph).
+2. Resource `vcon://v1/graph/shape` or tool `vcon_graph_shape`.
+3. Discovery resources such as `vcon://v1/discovery/analysis/types`, then search and fetch tools.
+
+The machine-readable JSON shape is documented by `VCON_SHAPE_GRAPH_JSON_SCHEMA` in `src/types/vcon-shape-graph.ts` (`schema_version` `1.0.0`).
+
+## Proprietary or customer-specific graphs
+
+Company ontologies, vertical taxonomies, merged “effective” graphs, external graph databases (for example FalkorDB), and analyst-specific bundles **do not** belong in the OSS core. They should attach through **plugins** and optional sidecar services so deployments without those products keep a single, spec-aligned code path.
+
+Plugins implement `VConPlugin` (`src/hooks/plugin-interface.ts`) and typically:
+
+- Register extra **tools** via `registerTools` (for example `implementation_taxonomy`, `graph_query`, overlay validators).
+- Register extra **resources** via `registerResources` (for example static ontology JSON or a merged graph snapshot URI).
+- Optionally implement `handleToolCall` for namespaced tool names and hooks such as `beforeSearch` / `afterSearch` to map neutral client filters to internal RPCs.
+
+The OSS server must not **require** any plugin for correct vCon CRUD, search, or the default shape graph. Heavy graph storage and proprietary merge logic stay in the plugin or in a separate process the customer runs; the MCP host wires them in through the plugin manager at startup.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -9,6 +9,7 @@ This section provides real-world examples of:
 - Search and query patterns
 - Plugin development
 - System integration
+- System instruction assets for Claude and other agents
 
 ## Quick Examples
 
@@ -98,6 +99,12 @@ await queries.addAnalysis(vconUuid, {
 - Webhook integration
 - CRM integration
 - Real-time updates
+
+### [System Instruction Assets](./system-instruction-assets.md)
+- Long reusable system instruction block
+- Short reusable system instruction block
+- Compact `CLAUDE.md` version
+- Stricter policy-style version
 
 ## Use Case Examples
 
@@ -194,4 +201,5 @@ npx tsx examples/plugin-demo.ts
 - Explore [Search Examples](./search-examples.md)
 - Build your own [Plugin](./plugin-examples.md)
 - See [Integration Examples](./integration-examples.md)
+- Reuse the [System Instruction Assets](./system-instruction-assets.md)
 

--- a/docs/examples/system-instruction-assets.md
+++ b/docs/examples/system-instruction-assets.md
@@ -1,0 +1,183 @@
+# System Instruction Assets
+
+Copy-paste instruction assets for clients, agents, and repository guidance that use the `vcon` MCP server effectively.
+
+These variants all encode the same core policy:
+- Prefer the redesigned contract tools
+- Use discovery-first retrieval
+- Treat `attachment.purpose` as canonical
+- Treat `attachment.type` as legacy compatibility only
+- Use tags only when the classification truly lives in tags
+
+## Long Version
+
+```text
+You are connected to the `vcon` MCP server for working with IETF vCon data.
+
+Prefer the redesigned contract tools for new work:
+- `vcon_capabilities` to discover supported modes, includes, pagination, limits, and byte budgets
+- `vcon_taxonomy` for dataset semantics, portal values, dealer-source guidance, and source-of-truth hints
+- `vcon_search` for search and listing
+- `vcon_fetch` for single-record reads
+- `describe_response_shape` if you need to confirm a response contract before using it
+
+Use a discovery-first strategy:
+- If the user wants data that may live in attachments or analysis, discover the live categories first
+- For attachments, `purpose` is the canonical spec field
+- For attachments, `type` is a legacy compatibility field and should only be used when older data still relies on it
+- For analysis, continue using `type`
+
+Prefer MCP resources for simple reads:
+- Attachment discovery:
+  - `vcon://v1/discovery/attachments/purposes`
+  - `vcon://v1/discovery/attachments/types` (legacy compatibility only)
+- Analysis discovery:
+  - `vcon://v1/discovery/analysis/types`
+- Attachment reads:
+  - `vcon://v1/vcons/{uuid}/attachments/purpose/{purpose}` (preferred)
+  - `vcon://v1/vcons/{uuid}/attachments/type/{type}` (legacy compatibility only)
+- Analysis reads:
+  - `vcon://v1/vcons/{uuid}/analysis/type/{type}`
+
+If you are using the REST API programmatically, follow the same pattern:
+- Discover:
+  - `GET /api/v1/discovery/attachments/purposes`
+  - `GET /api/v1/discovery/attachments/types` (legacy compatibility only)
+  - `GET /api/v1/discovery/analysis/types`
+- Then read:
+  - `GET /api/v1/vcons/:uuid/attachments?purpose={purpose}` (preferred)
+  - `GET /api/v1/vcons/:uuid/attachments?type={type}` (legacy compatibility only)
+  - `GET /api/v1/vcons/:uuid/analysis?type={type}`
+
+Important behavioral rules:
+- Do not jump to tags first for attachment-backed or analysis-backed classifications such as dealer info, summaries, transcripts, QA metadata, or similar fields
+- For attachments, prefer `purpose` before `type`
+- Use attachment `type` only when working with older or non-spec data
+- Use tags only when the classification genuinely lives in the tags attachment
+- Keep responses small and predictable: use `include`, `limit`, cursor pagination, metadata-only shapes, and `max_response_bytes` where available
+- If you get `RESPONSE_TOO_LARGE`, reduce `include`, lower `limit`, or switch to a lighter response shape and retry
+
+When to use which interface:
+- MCP resources are good for direct reads and lightweight discovery
+- MCP tools are better for search, pagination, and controlled retrieval
+- REST is best for external apps, scripts, and integrations
+- Direct Supabase access is best for trusted server-side analytics or bulk workflows, with care around RLS and service-role privileges
+
+Spec compliance rules:
+- `analysis.vendor` is required
+- `analysis.schema` is correct; do not use `schema_version`
+- `attachment.purpose` is the canonical attachment classification field
+- `attachment.type` should be treated as legacy compatibility metadata
+- `analysis.type` remains the correct classification field for analysis
+- Use `mediatype`, not `mimetype`
+- Use `critical`, not `must_support`
+- Use `amended`, not `appended`
+- Respect explicit encoding values when present
+```
+
+## Short Version
+
+```text
+Use the `vcon` MCP server in a discovery-first way.
+
+Prefer:
+- `vcon_capabilities`
+- `vcon_taxonomy`
+- `vcon_search`
+- `vcon_fetch`
+- `describe_response_shape`
+
+For attachment- or analysis-backed data:
+1. Discover categories first
+2. Read the matching filtered surface
+3. Use tags only if the classification actually lives in tags
+
+Canonical field rules:
+- Attachments: prefer `purpose`
+- Attachment `type` is legacy compatibility only
+- Analysis: use `type`
+
+Preferred MCP resources:
+- `vcon://v1/discovery/attachments/purposes`
+- `vcon://v1/discovery/analysis/types`
+- `vcon://v1/vcons/{uuid}/attachments/purpose/{purpose}`
+- `vcon://v1/vcons/{uuid}/analysis/type/{type}`
+
+Legacy-only attachment fallback:
+- `vcon://v1/discovery/attachments/types`
+- `vcon://v1/vcons/{uuid}/attachments/type/{type}`
+
+REST follows the same pattern:
+- Discover with `/api/v1/discovery/...`
+- Prefer `/api/v1/vcons/:uuid/attachments?purpose=...`
+- Use `/api/v1/vcons/:uuid/attachments?type=...` only for legacy data
+- Use `/api/v1/vcons/:uuid/analysis?type=...` for analysis
+
+Keep payloads small with `include`, `limit`, pagination, and `max_response_bytes`. If a response is too large, retry with a smaller shape.
+
+Remember:
+- `analysis.vendor` is required
+- `analysis.schema` is correct
+- `attachment.purpose` is canonical
+- `attachment.type` is legacy-only
+- `analysis.type` is still correct
+- `mediatype`, `critical`, and `amended` are the correct field names
+```
+
+## CLAUDE.md Version
+
+```text
+You are connected to the `vcon` MCP server for IETF vCon data. Prefer the redesigned contract tools: `vcon_capabilities`, `vcon_taxonomy`, `vcon_search`, `vcon_fetch`, and `describe_response_shape`. Use a discovery-first approach for attachment- or analysis-backed data. For attachments, `purpose` is the canonical spec field and `type` is legacy compatibility only; for analysis, continue using `type`. Prefer MCP discovery/read surfaces in this order: `vcon://v1/discovery/attachments/purposes`, `vcon://v1/discovery/analysis/types`, `vcon://v1/vcons/{uuid}/attachments/purpose/{purpose}`, `vcon://v1/vcons/{uuid}/analysis/type/{type}`. Only use `vcon://v1/discovery/attachments/types` or `vcon://v1/vcons/{uuid}/attachments/type/{type}` when older data still relies on attachment `type`. Do not jump to tags first for dealer info, summaries, transcripts, QA metadata, or other data that may live in attachments or analysis; use tags only when the classification truly lives in the tags attachment. Keep responses small and predictable with `include`, `limit`, pagination, metadata-only shapes, and `max_response_bytes`, and if a response is too large, retry with a smaller shape. Remember the key spec rules: `analysis.vendor` is required, `analysis.schema` is correct instead of `schema_version`, `mediatype` is correct instead of `mimetype`, `critical` replaces `must_support`, and `amended` replaces `appended`.
+```
+
+## Policy-Style Version
+
+```text
+You are connected to the `vcon` MCP server for IETF vCon data.
+
+Required defaults:
+- Prefer `vcon_capabilities`, `vcon_taxonomy`, `vcon_search`, `vcon_fetch`, and `describe_response_shape` for new work.
+- Use discovery-first retrieval before assuming field locations.
+- Keep responses minimal and predictable.
+
+Attachment and analysis policy:
+- Treat `attachment.purpose` as the canonical spec field.
+- Treat `attachment.type` as legacy compatibility only.
+- Treat `analysis.type` as the correct analysis classification field.
+- Do not treat attachment `type` and attachment `purpose` as equivalent in new designs.
+- Do not prefer attachment `type` when `purpose` can satisfy the request.
+- Do not use tags first when the requested data may live in attachments or analysis.
+- Use tags only when the classification genuinely lives in the tags attachment.
+
+Preferred MCP read order:
+1. `vcon://v1/discovery/attachments/purposes`
+2. `vcon://v1/discovery/analysis/types`
+3. `vcon://v1/vcons/{uuid}/attachments/purpose/{purpose}`
+4. `vcon://v1/vcons/{uuid}/analysis/type/{type}`
+
+Legacy-only attachment fallback:
+- `vcon://v1/discovery/attachments/types`
+- `vcon://v1/vcons/{uuid}/attachments/type/{type}`
+
+REST policy:
+- Follow the same discovery-first pattern with `/api/v1/discovery/...`
+- Prefer `GET /api/v1/vcons/:uuid/attachments?purpose={purpose}`
+- Use `GET /api/v1/vcons/:uuid/attachments?type={type}` only for legacy compatibility
+- Use `GET /api/v1/vcons/:uuid/analysis?type={type}` for analysis classification
+
+Response-shaping policy:
+- Use `include`, `limit`, pagination, metadata-only shapes, and `max_response_bytes` where available.
+- If a response is too large, reduce `include`, reduce `limit`, or choose a lighter shape and retry.
+- Prefer direct MCP resources for lightweight reads.
+- Prefer tools for search, pagination, and controlled retrieval.
+
+Spec compliance requirements:
+- `analysis.vendor` is required.
+- `analysis.schema` is correct; do not use `schema_version`.
+- `mediatype` is correct; do not use `mimetype`.
+- `critical` is correct; do not use `must_support`.
+- `amended` is correct; do not use `appended`.
+
+Behavioral rule:
+- If the user asks for dealer info, summary-like data, transcript-like data, QA metadata, or any other likely attachment- or analysis-backed classification, you must check purpose/type discovery surfaces before falling back to tags.
+```

--- a/docs/optimization/AGENT_PLAN_MCP_SERVER_QA.md
+++ b/docs/optimization/AGENT_PLAN_MCP_SERVER_QA.md
@@ -1,0 +1,166 @@
+# Agent plan: drive the vCon MCP server (errors, function, performance)
+
+Use this document as the operating brief for a coding agent whose job is to **exercise the MCP server end-to-end**, find **regressions and failure modes**, and characterize **latency and resource use**. Assume the repo is already built unless noted.
+
+---
+
+## 0. Preconditions
+
+| Item | Action |
+|------|--------|
+| Environment | `npm install` if needed; copy `.env` / Supabase keys per project README. |
+| Build | `npm run build` must succeed before any runtime work. |
+| Database | Confirm backend: Postgres (Supabase) or Mongo per config. `npm run db:status` or `npm run db:check` when available. |
+| Safety | For live MCP tool sweeps that mutate data, follow **`vcon-mcp-test` skill** (`~/.claude/skills/vcon-mcp-test/SKILL.md`): user-supplied UUID, explicit permission for create/delete, revert protocol. |
+
+Record **branch name**, **git SHA**, and **which profile** (`MCP_TOOLS_PROFILE`, tenant headers) you used in the final report.
+
+---
+
+## 1. Automated baseline (fast, no manual MCP client)
+
+Run in order; capture stdout and exit codes.
+
+1. **Unit and integration**  
+   `npx vitest run`  
+   Goal: all green. If failures, triage: handler vs DB mock vs assertion drift.
+
+2. **E2E** (if env has real DB / server wiring)  
+   `npm run test:e2e`  
+   Goal: no timeout flakes; note any test that assumes empty DB vs fixture.
+
+3. **Stress** (longer, broader surfaces)  
+   `npm run test:stress`  
+   Goal: resources list/read, full-coverage paths still pass.
+
+4. **Compliance** (spec drift)  
+   `npm run test:compliance`  
+   Goal: vCon shape and field names stay aligned with project rules.
+
+5. **Lint**  
+   `npm run lint`
+
+Optional repo scripts (when credentials allow real DB):
+
+- `npm run test:mcp` — `scripts/test-mcp-tools.ts`
+- `npm run test:search` / `npm run test:search:quick`
+- `npm run test:tenant` — RLS / tenant isolation
+- `npm run test:tags`
+
+Deliverable: **table** of command, pass/fail, duration, and one-line notes.
+
+---
+
+## 2. Functional: MCP contract and resources (read-heavy)
+
+Drive the same paths a client LLM would use. Prefer **stdio MCP** with the official inspector or a small script that calls `Client` from `@modelcontextprotocol/sdk`.
+
+Reference: `npm run test:console` → `npx @modelcontextprotocol/inspector tsx src/index.ts`
+
+### 2.1 Discovery order (capabilities first)
+
+- Call tool **`vcon_capabilities`**. Verify `tools` includes `vcon_graph_shape`, `shape_graph.resource_uri`, `shape_graph.json_schema_id`.
+- Read resource **`vcon://v1/graph/shape`**. Validate JSON against expectations in `src/types/vcon-shape-graph.ts` (`schema_version`, `nodes[].kind`, `edges[].joint_vcon_count` when present).
+- Call tool **`vcon_graph_shape`**. Assert payload equals resource body (same logical graph; `generated_at` may differ).
+
+### 2.2 Discovery resources
+
+Read each; confirm JSON parses and counts are non-negative:
+
+- `vcon://v1/discovery/attachments/purposes`
+- `vcon://v1/discovery/attachments/types`
+- `vcon://v1/discovery/analysis/types`
+
+### 2.3 Contract tools (envelopes and errors)
+
+| Tool | What to verify |
+|------|------------------|
+| `vcon_fetch` | Valid UUID: `{ ok: true, item.id }`. Invalid UUID / not found: `{ ok: false, error.code }`. `RESPONSE_TOO_LARGE` with tiny `max_response_bytes` and heavy `include`. |
+| `vcon_search` | Each mode: `metadata`, `keyword`, `semantic`, `hybrid` (semantic/hybrid need embeddings or server support). Cursor round-trip. |
+| `describe_response_shape` | List mode; then `tool_name` for `vcon_graph_shape`, `vcon_fetch`, `vcon_search`. |
+| `vcon_aggregate` | Expected success or documented `AGGREGATE_FAILED` if RPC missing. |
+
+### 2.4 Legacy tools (spot-check)
+
+Sample **`get_vcon`**, **`search_vcons`**, tag tools, and one analytics tool to ensure the registry still dispatches and envelopes match docs.
+
+Deliverable: **checklist** with pass/fail and pasted **error codes** only (not full payloads).
+
+---
+
+## 3. Errors and edge cases (intentional abuse)
+
+Design tests so the server **fails safely** (structured errors, no crash, no unbounded memory).
+
+| Category | Examples |
+|----------|----------|
+| Invalid params | Bad UUID, unknown `include`, bad `mode`, malformed tags object, `limit` over max. |
+| Missing backend | Wrong Supabase URL or key: tools should return errors, not hang. |
+| Empty corpus | Discovery returns empty arrays; shape graph still valid with `nodes: []`. |
+| Large responses | `vcon_search` / `vcon_fetch` with `max_response_bytes` set low; confirm `RESPONSE_TOO_LARGE` and suggestions. |
+| Tenant | If multi-tenant: repeat a read with wrong `x-tenant-id` (or env) and confirm isolation or expected 403/empty behavior per `src/config/tenant-config.ts`. |
+
+Deliverable: **matrix** (input class → HTTP/MCP outcome → log line if any).
+
+---
+
+## 4. Performance (measurable, comparable)
+
+Use the **same machine** and note cold vs warm. Prefer wall-clock and log timestamps; optional `console.time` in a one-off script under `scripts/` if you add one (do not commit noisy logging unless asked).
+
+### 4.1 Candidate hot paths
+
+1. **`getVconShapeGraph`** (Postgres `exec_sql` path vs fallback in `src/db/queries.ts`). Time repeated calls; check `corpus.notes` for which path ran.
+2. **Discovery aggregates** — `getUniqueAttachmentPurposes`, `getUniqueAnalysisTypes`, tag distinct queries.
+3. **`vcon_search`** — metadata with tag sort window; keyword; semantic with embedding.
+4. **Resource `vcon://v1/vcons/ids`** with pagination — large `limit` vs default.
+
+### 4.2 Database-level checks (Postgres)
+
+When allowed:
+
+- `npm run analyze:indexes` or `analyze_query` tool on representative SQL (search, shape graph, discovery).
+- Compare **EXPLAIN** vs **EXPLAIN ANALYZE** for sequential scans on large tables.
+
+### 4.3 SLO-style targets (fill in after first baseline)
+
+Document p50/p95 for:
+
+- `vcon_capabilities` (should be tiny)
+- `vcon://v1/graph/shape` read
+- `vcon_search` metadata page (default limit)
+
+Deliverable: **small table** of operation, N iterations, p50, p95, and whether Redis cache was on (`Cache layer` log lines).
+
+---
+
+## 5. Observability and logs
+
+- Watch for **`Cache layer disabled`** vs enabled when testing repeat reads.
+- Correlate **`withSpan`** / tool name attributes if OpenTelemetry is configured.
+- On failure, capture **first stack trace** and the **tool name + args** (redact secrets).
+
+---
+
+## 6. Exit criteria for the agent
+
+The run is complete when:
+
+1. Automated suite results are summarized (section 1).
+2. At least one **manual or inspector** session covered sections 2.1–2.3.
+3. At least **three** error classes from section 3 were exercised with recorded outcomes.
+4. Section 4 has **numbers** for at least two hot paths, or a written reason they could not be measured (e.g. no DB access).
+5. A short **follow-up list** of bugs or PR-sized fixes is ranked (P0/P1/P2).
+
+---
+
+## 7. Related docs in this repo
+
+- `CLAUDE.md` — spec compliance checklist and tool overview.
+- `docs/optimization/SESSION_HANDOFF_FOR_VAULT.md` — recent feature checkpoint.
+- `docs/api/shape-graph-and-plugins.md` — shape graph and plugin boundaries.
+- `tests/stress/full-coverage.test.ts` — resource URLs used in stress runs.
+
+---
+
+*This plan is read-only guidance; update it when new tools or transport modes (HTTP MCP, etc.) ship.*

--- a/docs/optimization/SESSION_HANDOFF_FOR_VAULT.md
+++ b/docs/optimization/SESSION_HANDOFF_FOR_VAULT.md
@@ -1,0 +1,103 @@
+---
+title: vCon MCP session handoff (optimization-ready)
+date: 2026-05-13
+tags:
+  - vcon-mcp
+  - mcp
+  - rest
+  - purpose-vs-type
+  - discovery
+---
+
+# Session handoff (paste into vault or attach to next thread)
+
+## What was implemented (high level)
+
+- **Discovery-first read surfaces** for attachment and analysis categories across **MCP resources** and **REST**.
+- **Canonical rule**: `attachment.purpose` is spec-facing; `attachment.type` is **legacy compatibility only**. **`analysis.type`** unchanged.
+- **Query layer**: distinct values for attachment types, attachment purposes, analysis types (Supabase + Mongo); Supabase **persists and reads `attachment.purpose`**.
+- **Shared helpers**: `src/utils/read-surfaces.ts` (filter, tags extract, discovery value shaping).
+- **Docs**: REST + resources + README; **four system-instruction copy-pastes** in `docs/examples/system-instruction-assets.md`; **thread bootstrap** in `docs/optimization/thread-context-bootstrap.md`.
+
+## URIs and REST (cheat sheet)
+
+**MCP discovery**
+
+- `vcon://v1/discovery/attachments/purposes` (preferred)
+- `vcon://v1/discovery/attachments/types` (legacy)
+- `vcon://v1/discovery/analysis/types`
+
+**MCP filtered reads**
+
+- `vcon://v1/vcons/{uuid}/attachments/purpose/{purpose}` (preferred)
+- `vcon://v1/vcons/{uuid}/attachments/type/{type}` (legacy)
+- `vcon://v1/vcons/{uuid}/analysis/type/{type}`
+
+**REST**
+
+- `GET /api/v1/discovery/attachments/purposes`
+- `GET /api/v1/discovery/attachments/types`
+- `GET /api/v1/discovery/analysis/types`
+- `GET /api/v1/vcons/:uuid/attachments?purpose=...` (preferred)
+- `GET /api/v1/vcons/:uuid/attachments?type=...` (legacy)
+- `GET /api/v1/vcons/:uuid/analysis?type=...`
+
+## Key files
+
+| Area | Path |
+|------|------|
+| MCP resource list + resolve | `src/resources/index.ts` |
+| REST discovery | `src/api/routes/discovery.ts` |
+| REST vCon reads | `src/api/routes/vcons.ts` |
+| Router mount | `src/api/rest-router.ts` |
+| Filters | `src/utils/read-surfaces.ts` |
+| Types | `src/types/vcon.ts` |
+| IVConQueries | `src/db/interfaces.ts` |
+| Supabase | `src/db/queries.ts` |
+| Mongo | `src/db/mongo-queries.ts` |
+| add_attachment schema | `src/tools/vcon-crud.ts` |
+| Instruction assets (4 variants) | `docs/examples/system-instruction-assets.md` |
+| Optimization bootstrap | `docs/optimization/thread-context-bootstrap.md` |
+
+## Tests touched / added
+
+- `tests/new-tools-resources.test.ts`
+- `tests/api/routes/discovery.test.ts`
+- `tests/api/routes/vcons.test.ts`
+- `tests/db-queries.test.ts`
+- `tests/api/helpers.ts`
+
+## Commands that were green
+
+- `npm run build`
+- `npx vitest run` (targeted suites during work)
+- `npm run docs:build`
+
+## Policy for agents (one line)
+
+Discover **attachment purposes** and **analysis types** first; read by **`purpose`** for attachments and **`type`** for analysis; use **`attachment.type` only for legacy data**; use **tags** only when data lives in tags.
+
+## Next thread (optimization) — suggested focus
+
+- Performance of distinct-category queries at scale (SQL vs batch fallback).
+- Whether to add **write-path normalization** (`type` → `purpose`) on ingest.
+- Optional deprecation timeline for attachment-`type` discovery surfaces.
+
+## Checkpoint 2026-05-13 — shape graph, capabilities, tests
+
+**Shipped in repo (local commit, not pushed)**
+
+- **OSS shape graph**: `src/types/vcon-shape-graph.ts`; `getVconShapeGraph()` on `IVConQueries` with Postgres materialization (SQL path + fallback) and Mongo implementation; optional co-occurrence edges where supported.
+- **Surfaces**: MCP resource `vcon://v1/graph/shape`; read tool `vcon_graph_shape`; `vcon_capabilities` lists the tool and a `shape_graph` block (resource URI, JSON schema id, short description). `describe_response_shape` includes `vcon_graph_shape`.
+- **Docs**: `docs/api/shape-graph-and-plugins.md` (default graph plus how proprietary graphs attach via plugins).
+- **Tests**: `tests/handlers/schema.test.ts` and `tests/tools/templates.test.ts` aligned to 0.4.0 and real handler responses (raw JSON Schema for `get_schema`, file body for TypeScript mode); registry and tool-category counts; resource tests for shape graph; stress read for `vcon://v1/graph/shape`.
+
+**Suggested next hardening pass**
+
+- Re-read SQL for `getVconShapeGraph` under tenant RLS and large corpora (timeouts, `exec_sql` availability).
+- Optional caching for shape graph (same Redis optional pattern as other queries).
+- Contract tests for `SHAPE_GRAPH_FAILED` and oversized payloads if you add strict byte limits later.
+
+---
+
+*Copy this file into your vault, or keep it in-repo and `@` it from the optimization thread.*

--- a/docs/optimization/thread-context-bootstrap.md
+++ b/docs/optimization/thread-context-bootstrap.md
@@ -1,0 +1,67 @@
+# Optimization thread bootstrap (saved context)
+
+Use this file at the start of an optimization thread. It summarizes decisions, behavior, and where assets live.
+
+## Purpose vs type (attachments)
+
+- **`attachment.purpose`** is the **canonical** spec-facing classification field for attachments.
+- **`attachment.type`** is **legacy / compatibility only** (e.g. older data, Strolid-style metadata). Do not treat it as equivalent to `purpose` for new designs.
+- **`analysis.type`** remains the correct classification field for analysis (unchanged).
+
+### Read / discovery order (preferred)
+
+1. Discover attachment purposes: `vcon://v1/discovery/attachments/purposes` or `GET /api/v1/discovery/attachments/purposes`
+2. Discover analysis types: `vcon://v1/discovery/analysis/types` or `GET /api/v1/discovery/analysis/types`
+3. Read attachments by purpose: `vcon://v1/vcons/{uuid}/attachments/purpose/{purpose}` or `GET /api/v1/vcons/:uuid/attachments?purpose=...`
+4. Read analysis by type: `vcon://v1/vcons/{uuid}/analysis/type/{type}` or `GET /api/v1/vcons/:uuid/analysis?type=...`
+
+### Legacy-only attachment paths
+
+- `vcon://v1/discovery/attachments/types` / `GET /api/v1/discovery/attachments/types`
+- `vcon://v1/vcons/{uuid}/attachments/type/{type}` / `GET /api/v1/vcons/:uuid/attachments?type=...`
+
+### Tags
+
+- Do **not** jump to tags first for dealer-like, summary-like, transcript-like, or other attachment/analysis-backed data.
+- Use tags only when classification **actually** lives in the tags attachment.
+
+## Contract tools (recommended for agents)
+
+Prefer: `vcon_capabilities`, `vcon_taxonomy`, `vcon_search`, `vcon_fetch`, `describe_response_shape`.
+
+Payload discipline: `include`, `limit`, pagination, metadata-only shapes, `max_response_bytes`; on `RESPONSE_TOO_LARGE`, shrink and retry.
+
+## Spec reminders (high signal)
+
+- `analysis.vendor` required; `analysis.schema` not `schema_version`; `body` as string when structured JSON is stored.
+- `mediatype` not `mimetype`; `critical` not `must_support`; `amended` not `appended`.
+
+## Code / docs touchpoints (for optimization work)
+
+- Types: `src/types/vcon.ts` (`Attachment.purpose` vs optional `type`).
+- MCP resources: `src/resources/index.ts` (discovery + filtered reads; purpose-first descriptions).
+- REST: `src/api/routes/discovery.ts`, `src/api/routes/vcons.ts`, mount in `src/api/rest-router.ts`.
+- Shared filters: `src/utils/read-surfaces.ts`.
+- Query layer: `src/db/interfaces.ts`, `src/db/queries.ts`, `src/db/mongo-queries.ts` (distinct discovery + Supabase `purpose` round-trip on attachments).
+- Tool schema: `src/tools/vcon-crud.ts` (`AttachmentSchema` documents purpose vs type).
+- Tests: `tests/new-tools-resources.test.ts`, `tests/api/routes/discovery.test.ts`, `tests/api/routes/vcons.test.ts`, `tests/db-queries.test.ts`, `tests/api/helpers.ts`.
+
+## Documentation assets (system instructions)
+
+Full copy-paste variants live in:
+
+- `docs/examples/system-instruction-assets.md` (long, short, CLAUDE.md one-paragraph, strict policy-style)
+
+Linked from:
+
+- `docs/examples/index.md`
+- `docs/SUMMARY.md`
+
+## Verification notes
+
+- `npm run build` and targeted Vitest suites were used during implementation.
+- `npm run docs:build` succeeded after adding the system-instruction assets page.
+
+---
+
+*This file is intentionally dense so a new thread can load one artifact instead of replaying the whole conversation.*

--- a/src/api/rest-router.ts
+++ b/src/api/rest-router.ts
@@ -16,6 +16,7 @@ import { createAuthMiddleware, errorHandler, getAuthConfig, requestLogger } from
 import type { RestApiContext } from './context.js';
 import { createAnalyticsRoutes } from './routes/analytics.js';
 import { createDatabaseRoutes } from './routes/database.js';
+import { createDiscoveryRoutes } from './routes/discovery.js';
 import { createSchemaRoutes } from './routes/schema.js';
 import { createSearchRoutes } from './routes/search.js';
 import { createTagRoutes } from './routes/tags.js';
@@ -114,6 +115,10 @@ export function createRestApi(apiContext: RestApiContext, config?: Partial<RestA
   // Search routes — MUST be before /vcons/:uuid to avoid "search" matching as UUID
   const searchRouter = createSearchRoutes(apiContext);
   router.use(searchRouter.routes());
+
+  // Discovery routes for live attachment and analysis categories
+  const discoveryRouter = createDiscoveryRoutes(apiContext);
+  router.use(discoveryRouter.routes());
 
   // Tag collection routes (/tags, /tags/search)
   const tagRouter = createTagRoutes(apiContext);

--- a/src/api/routes/discovery.ts
+++ b/src/api/routes/discovery.ts
@@ -1,0 +1,82 @@
+import Router from '@koa/router';
+import type { Context } from 'koa';
+import type { RestApiContext } from '../context.js';
+import { sendError, sendSuccess } from '../response.js';
+import { toDiscoveryValues } from '../../utils/read-surfaces.js';
+
+function parseIncludeCounts(value: string | string[] | undefined): boolean {
+  if (typeof value !== 'string') {
+    return true;
+  }
+  return value !== 'false';
+}
+
+function parseMinCount(ctx: Context): number | undefined {
+  const raw = ctx.query.min_count;
+  if (raw === undefined) {
+    return 1;
+  }
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return undefined;
+  }
+  return parsed;
+}
+
+export function createDiscoveryRoutes(apiContext: RestApiContext): Router {
+  const router = new Router();
+
+  const handleDiscovery = async (
+    ctx: Context,
+    key: 'attachment_types' | 'attachment_purposes' | 'analysis_types',
+    fetcher: (options: { includeCounts?: boolean; minCount?: number }) => Promise<{
+      values: string[];
+      countsPerValue?: Record<string, number>;
+      totalVCons: number;
+    }>,
+  ) => {
+    const minCount = parseMinCount(ctx);
+    if (!minCount) {
+      return sendError(ctx, 400, 'min_count must be an integer greater than or equal to 1');
+    }
+
+    const includeCounts = parseIncludeCounts(ctx.query.include_counts as string | string[] | undefined);
+    const result = await fetcher({ includeCounts, minCount });
+    sendSuccess(ctx, {
+      count: result.values.length,
+      total_vcons: result.totalVCons,
+      [key]: toDiscoveryValues(result),
+    });
+  };
+
+  router.get('/discovery/attachments/types', async (ctx: Context) => {
+    // Legacy compatibility surface. Prefer attachment purposes for spec-facing clients.
+    await handleDiscovery(
+      ctx,
+      'attachment_types',
+      (options) => apiContext.queries.getUniqueAttachmentTypes(options),
+    );
+  });
+
+  router.get('/discovery/attachments/purposes', async (ctx: Context) => {
+    // Canonical spec-facing attachment discovery surface.
+    await handleDiscovery(
+      ctx,
+      'attachment_purposes',
+      (options) => apiContext.queries.getUniqueAttachmentPurposes(options),
+    );
+  });
+
+  router.get('/discovery/analysis/types', async (ctx: Context) => {
+    await handleDiscovery(
+      ctx,
+      'analysis_types',
+      (options) => apiContext.queries.getUniqueAnalysisTypes(options),
+    );
+  });
+
+  return router;
+}

--- a/src/api/routes/vcons.ts
+++ b/src/api/routes/vcons.ts
@@ -20,6 +20,7 @@ import {
 } from '../validation.js';
 import { VConValidationError } from '../../services/vcon-service.js';
 import { logWithContext, recordCounter } from '../../observability/instrumentation.js';
+import { filterAnalysis, filterAttachments } from '../../utils/read-surfaces.js';
 
 /**
  * Format a vCon based on response_format parameter
@@ -38,7 +39,7 @@ function formatVCon(vcon: VCon, format: string): any {
     };
   }
   if (format === 'summary') {
-    const summaryAnalysis = (vcon.analysis || []).filter((a: any) => a.type === 'summary');
+    const summaryAnalysis = filterAnalysis(vcon, { type: 'summary' });
     return {
       vcon: vcon.vcon,
       uuid: vcon.uuid,
@@ -52,6 +53,10 @@ function formatVCon(vcon: VCon, format: string): any {
     };
   }
   return vcon;
+}
+
+function getQueryStringValue(value: string | string[] | undefined): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
 }
 
 /**
@@ -210,6 +215,62 @@ export function createVConRoutes(apiContext: RestApiContext): Router {
         requestContext: { purpose: 'rest-api-read' },
       });
       sendSuccess(ctx, { vcon: formatVCon(vcon, format) });
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('not found')) {
+        return sendError(ctx, 404, `vCon with UUID ${uuid} not found`);
+      }
+      throw error;
+    }
+  });
+
+  // ── GET /vcons/:uuid/analysis — Read analysis with optional type filter ───
+  router.get('/vcons/:uuid/analysis', async (ctx: Context) => {
+    const { uuid } = ctx.params;
+    const uuidCheck = validateUUID(uuid);
+    if (!uuidCheck.valid) return sendError(ctx, 400, uuidCheck.errors[0]);
+
+    const type = getQueryStringValue(ctx.query.type as string | string[] | undefined);
+
+    try {
+      const vcon = await apiContext.vconService.get(uuid, {
+        requestContext: { purpose: 'rest-api-analysis-read' },
+      });
+      const analysis = filterAnalysis(vcon, { type });
+      sendSuccess(ctx, {
+        count: analysis.length,
+        ...(type ? { type } : {}),
+        analysis,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('not found')) {
+        return sendError(ctx, 404, `vCon with UUID ${uuid} not found`);
+      }
+      throw error;
+    }
+  });
+
+  // ── GET /vcons/:uuid/attachments — Read attachments with purpose-first filters ──
+  router.get('/vcons/:uuid/attachments', async (ctx: Context) => {
+    const { uuid } = ctx.params;
+    const uuidCheck = validateUUID(uuid);
+    if (!uuidCheck.valid) return sendError(ctx, 400, uuidCheck.errors[0]);
+
+    const type = getQueryStringValue(ctx.query.type as string | string[] | undefined);
+    const purpose = getQueryStringValue(ctx.query.purpose as string | string[] | undefined);
+
+    try {
+      const vcon = await apiContext.vconService.get(uuid, {
+        requestContext: { purpose: 'rest-api-attachment-read' },
+      });
+      // Purpose is the canonical spec-facing attachment classifier.
+      // Type remains available as a legacy compatibility filter.
+      const attachments = filterAttachments(vcon, { type, purpose });
+      sendSuccess(ctx, {
+        count: attachments.length,
+        ...(type ? { type } : {}),
+        ...(purpose ? { purpose } : {}),
+        attachments,
+      });
     } catch (error) {
       if (error instanceof Error && error.message.includes('not found')) {
         return sendError(ctx, 404, `vCon with UUID ${uuid} not found`);

--- a/src/db/interfaces.ts
+++ b/src/db/interfaces.ts
@@ -6,6 +6,7 @@
  */
 
 import { Analysis, Attachment, Dialog, VCon } from '../types/vcon.js';
+import type { VconShapeGraphPayload } from '../types/vcon-shape-graph.js';
 
 export interface SearchResult {
     vcon_id: string;
@@ -260,4 +261,11 @@ export interface IVConQueries {
         includeCounts?: boolean;
         minCount?: number;
     }): Promise<DistinctValuesResult>;
+
+    /**
+     * Default OSS "shape graph": distinct vCon incidence for analysis types,
+     * attachment purposes, legacy attachment types (no purpose), tag keys,
+     * and bounded analysis-type to attachment-purpose co-occurrence edges.
+     */
+    getVconShapeGraph(): Promise<VconShapeGraphPayload>;
 }

--- a/src/db/interfaces.ts
+++ b/src/db/interfaces.ts
@@ -23,6 +23,12 @@ export interface SearchResult {
     similarity?: number;
 }
 
+export interface DistinctValuesResult {
+    values: string[];
+    countsPerValue?: Record<string, number>;
+    totalVCons: number;
+}
+
 export interface IVConQueries {
     /**
      * Initialize the database connection and schema (e.g. indexes)
@@ -129,6 +135,10 @@ export interface IVConQueries {
         startDate?: string;
         endDate?: string;
         tags?: Record<string, string>;
+        /** Match strolid_dealer attachment id (string form, for example "1174"). */
+        dealerId?: string;
+        /** Case-insensitive substring match on strolid_dealer attachment name. */
+        dealerName?: string;
         limit?: number;
     }): Promise<VCon[]>;
 
@@ -143,7 +153,36 @@ export interface IVConQueries {
         startDate?: string;
         endDate?: string;
         tags?: Record<string, string>;
+        dealerId?: string;
+        dealerName?: string;
     }): Promise<number>;
+
+    /**
+     * Roll up vCons with strolid_dealer attachments by dealer id (Postgres RPC).
+     */
+    aggregateVconsByDealerStats(params: {
+        tagFilter: Record<string, string>;
+        startDate?: string;
+        endDate?: string;
+        minBaseline: number;
+        limit: number;
+    }): Promise<Array<{
+        dealer_id: string;
+        dealer_name: string | null;
+        team_id: number | null;
+        team_name: string | null;
+        filtered_count: number;
+        baseline_count: number;
+    }>>;
+
+    /**
+     * Optional DB-backed coverage hints for taxonomy (best-effort; may omit on error).
+     */
+    getTaxonomyCoverageSnapshot(): Promise<{
+        vcons_total: number | null;
+        with_strolid_dealer_attachment_pct: number | null;
+        with_dealer_name_tag_pct: number | null;
+    }>;
 
     /**
      * Update vCon metadata (subject, extensions, must_support)
@@ -195,4 +234,30 @@ export interface IVConQueries {
         countsPerValue?: Record<string, Record<string, number>>;
         totalVCons: number;
     }>;
+
+    /**
+     * Get all unique legacy attachment types (and optionally counts) across the database.
+     * Prefer attachment purposes for spec-facing discovery.
+     */
+    getUniqueAttachmentTypes(options?: {
+        includeCounts?: boolean;
+        minCount?: number;
+    }): Promise<DistinctValuesResult>;
+
+    /**
+     * Get all unique attachment purposes (and optionally counts) across the database.
+     * This is the canonical spec-facing attachment classification surface.
+     */
+    getUniqueAttachmentPurposes(options?: {
+        includeCounts?: boolean;
+        minCount?: number;
+    }): Promise<DistinctValuesResult>;
+
+    /**
+     * Get all unique analysis types (and optionally counts) across the database
+     */
+    getUniqueAnalysisTypes(options?: {
+        includeCounts?: boolean;
+        minCount?: number;
+    }): Promise<DistinctValuesResult>;
 }

--- a/src/db/mongo-queries.ts
+++ b/src/db/mongo-queries.ts
@@ -4,6 +4,11 @@
 
 import { Db, ObjectId } from 'mongodb';
 import { Analysis, Attachment, Dialog, VCon } from '../types/vcon.js';
+import {
+    VCON_SHAPE_GRAPH_SCHEMA_VERSION,
+    type VconShapeGraphNode,
+    type VconShapeGraphPayload,
+} from '../types/vcon-shape-graph.js';
 import { DistinctValuesResult, IVConQueries } from './interfaces.js';
 import { logWithContext, recordCounter, withSpan } from '../observability/instrumentation.js';
 import { ATTR_DB_OPERATION, ATTR_SEARCH_RESULTS_COUNT, ATTR_SEARCH_THRESHOLD, ATTR_SEARCH_TYPE, ATTR_VCON_UUID } from '../observability/attributes.js';
@@ -646,6 +651,71 @@ export class MongoVConQueries implements IVConQueries {
         minCount?: number;
     }): Promise<DistinctValuesResult> {
         return this.getDistinctArrayValues('analysis', 'type', options);
+    }
+
+    async getVconShapeGraph(): Promise<VconShapeGraphPayload> {
+        const notes: string[] = [
+            'MongoDB backend: vcon_count on analysis and attachment nodes reflects tallied rows across documents, not guaranteed distinct vCon UUIDs. Tag vcon_count sums value-level counts.',
+        ];
+        const generated_at = new Date().toISOString();
+        const nodes: VconShapeGraphNode[] = [];
+        const nodeId = (kind: VconShapeGraphNode['kind'], label: string) =>
+            `${kind}:${encodeURIComponent(label)}`;
+
+        const [analysis, purposes, types, tags] = await Promise.all([
+            this.getUniqueAnalysisTypes({ includeCounts: true }),
+            this.getUniqueAttachmentPurposes({ includeCounts: true }),
+            this.getUniqueAttachmentTypes({ includeCounts: true }),
+            this.getUniqueTags({ includeCounts: true }),
+        ]);
+
+        for (const v of analysis.values) {
+            nodes.push({
+                id: nodeId('analysis_type', v),
+                kind: 'analysis_type',
+                label: v,
+                ...(analysis.countsPerValue ? { vcon_count: analysis.countsPerValue[v] } : {}),
+            });
+        }
+        for (const v of purposes.values) {
+            nodes.push({
+                id: nodeId('attachment_purpose', v),
+                kind: 'attachment_purpose',
+                label: v,
+                ...(purposes.countsPerValue ? { vcon_count: purposes.countsPerValue[v] } : {}),
+            });
+        }
+        for (const v of types.values) {
+            nodes.push({
+                id: nodeId('attachment_type_legacy', v),
+                kind: 'attachment_type_legacy',
+                label: v,
+                ...(types.countsPerValue ? { vcon_count: types.countsPerValue[v] } : {}),
+            });
+        }
+        for (const k of tags.keys) {
+            let approx: number | undefined;
+            if (tags.countsPerValue?.[k]) {
+                approx = Object.values(tags.countsPerValue[k]).reduce((a, b) => a + b, 0);
+            }
+            nodes.push({
+                id: nodeId('tag_key', k),
+                kind: 'tag_key',
+                label: k,
+                ...(approx !== undefined ? { vcon_count: approx } : {}),
+            });
+        }
+
+        return {
+            schema_version: VCON_SHAPE_GRAPH_SCHEMA_VERSION,
+            generated_at,
+            corpus: {
+                vcons_with_tags_mv: tags.totalVCons,
+                notes,
+            },
+            nodes,
+            edges: [],
+        };
     }
 
     async aggregateVconsByDealerStats(_params: {

--- a/src/db/mongo-queries.ts
+++ b/src/db/mongo-queries.ts
@@ -4,7 +4,7 @@
 
 import { Db, ObjectId } from 'mongodb';
 import { Analysis, Attachment, Dialog, VCon } from '../types/vcon.js';
-import { IVConQueries } from './interfaces.js';
+import { DistinctValuesResult, IVConQueries } from './interfaces.js';
 import { logWithContext, recordCounter, withSpan } from '../observability/instrumentation.js';
 import { ATTR_DB_OPERATION, ATTR_SEARCH_RESULTS_COUNT, ATTR_SEARCH_THRESHOLD, ATTR_SEARCH_TYPE, ATTR_VCON_UUID } from '../observability/attributes.js';
 
@@ -399,6 +399,8 @@ export class MongoVConQueries implements IVConQueries {
         startDate?: string;
         endDate?: string;
         tags?: Record<string, string>;
+        dealerId?: string;
+        dealerName?: string;
         limit?: number;
     }): Promise<VCon[]> {
         const collection = this.db.collection(this.VCONS_COLLECTION);
@@ -444,6 +446,8 @@ export class MongoVConQueries implements IVConQueries {
         startDate?: string;
         endDate?: string;
         tags?: Record<string, string>;
+        dealerId?: string;
+        dealerName?: string;
     }): Promise<number> {
         const collection = this.db.collection(this.VCONS_COLLECTION);
         const query: Record<string, any> = {};
@@ -520,6 +524,67 @@ export class MongoVConQueries implements IVConQueries {
         return results.map((r: any) => r.uuid);
     }
 
+    private async getDistinctArrayValues(
+        arrayField: 'attachments' | 'analysis',
+        valueField: 'type' | 'purpose',
+        options?: {
+            includeCounts?: boolean;
+            minCount?: number;
+        }
+    ): Promise<DistinctValuesResult> {
+        const collection = this.db.collection(this.VCONS_COLLECTION);
+        const docs = await collection
+            .find({})
+            .project({ uuid: 1, [arrayField]: 1 })
+            .toArray();
+
+        const includeCounts = options?.includeCounts ?? false;
+        const minCount = options?.minCount ?? 1;
+        const values = new Set<string>();
+        const countsPerValue: Record<string, number> = {};
+        const vconIds = new Set<string>();
+
+        for (const doc of docs) {
+            const entries = Array.isArray((doc as any)[arrayField]) ? (doc as any)[arrayField] : [];
+            let hasValueForDoc = false;
+
+            for (const entry of entries) {
+                const rawValue = entry?.[valueField];
+                const value = typeof rawValue === 'string' ? rawValue.trim() : '';
+                if (!value) continue;
+
+                values.add(value);
+                countsPerValue[value] = (countsPerValue[value] || 0) + 1;
+                hasValueForDoc = true;
+            }
+
+            if (hasValueForDoc && typeof (doc as any).uuid === 'string') {
+                vconIds.add((doc as any).uuid);
+            }
+        }
+
+        const sortedValues = Array.from(values)
+            .filter((value) => countsPerValue[value] >= minCount)
+            .sort((a, b) => {
+                const countDiff = countsPerValue[b] - countsPerValue[a];
+                return countDiff !== 0 ? countDiff : a.localeCompare(b);
+            });
+
+        const result: DistinctValuesResult = {
+            values: sortedValues,
+            totalVCons: vconIds.size,
+        };
+
+        if (includeCounts) {
+            result.countsPerValue = {};
+            for (const value of sortedValues) {
+                result.countsPerValue[value] = countsPerValue[value];
+            }
+        }
+
+        return result;
+    }
+
     async getUniqueTags(options?: {
         includeCounts?: boolean;
         keyFilter?: string;
@@ -560,5 +625,55 @@ export class MongoVConQueries implements IVConQueries {
         const result: Record<string, string[]> = {};
         for (const [k, vs] of Object.entries(tagsByKey)) result[k] = Array.from(vs);
         return { keys: Object.keys(result), tagsByKey: result, totalVCons };
+    }
+
+    async getUniqueAttachmentTypes(options?: {
+        includeCounts?: boolean;
+        minCount?: number;
+    }): Promise<DistinctValuesResult> {
+        return this.getDistinctArrayValues('attachments', 'type', options);
+    }
+
+    async getUniqueAttachmentPurposes(options?: {
+        includeCounts?: boolean;
+        minCount?: number;
+    }): Promise<DistinctValuesResult> {
+        return this.getDistinctArrayValues('attachments', 'purpose', options);
+    }
+
+    async getUniqueAnalysisTypes(options?: {
+        includeCounts?: boolean;
+        minCount?: number;
+    }): Promise<DistinctValuesResult> {
+        return this.getDistinctArrayValues('analysis', 'type', options);
+    }
+
+    async aggregateVconsByDealerStats(_params: {
+        tagFilter: Record<string, string>;
+        startDate?: string;
+        endDate?: string;
+        minBaseline: number;
+        limit: number;
+    }): Promise<Array<{
+        dealer_id: string;
+        dealer_name: string | null;
+        team_id: number | null;
+        team_name: string | null;
+        filtered_count: number;
+        baseline_count: number;
+    }>> {
+        return [];
+    }
+
+    async getTaxonomyCoverageSnapshot(): Promise<{
+        vcons_total: number | null;
+        with_strolid_dealer_attachment_pct: number | null;
+        with_dealer_name_tag_pct: number | null;
+    }> {
+        return {
+            vcons_total: null,
+            with_strolid_dealer_attachment_pct: null,
+            with_dealer_name_tag_pct: null,
+        };
     }
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -16,6 +16,12 @@ import { ATTR_CACHE_HIT, ATTR_DB_OPERATION, ATTR_SEARCH_RESULTS_COUNT, ATTR_SEAR
 import { logWithContext, recordCounter, withSpan } from '../observability/instrumentation.js';
 import { createLogger } from '../observability/logger.js';
 import { Analysis, Attachment, Dialog, VCon } from '../types/vcon.js';
+import {
+  VCON_SHAPE_GRAPH_SCHEMA_VERSION,
+  type VconShapeGraphEdge,
+  type VconShapeGraphNode,
+  type VconShapeGraphPayload,
+} from '../types/vcon-shape-graph.js';
 import { deserializeBody, serializeBody } from '../utils/body-serialization.js';
 
 const logger = createLogger('queries');
@@ -1929,6 +1935,211 @@ export class SupabaseVConQueries implements IVConQueries {
     minCount?: number;
   }): Promise<DistinctValuesResult> {
     return this.getDistinctValues('analysis', 'type', options);
+  }
+
+  async getVconShapeGraph(): Promise<VconShapeGraphPayload> {
+    const notes: string[] = [];
+    const generated_at = new Date().toISOString();
+    const nodes: VconShapeGraphNode[] = [];
+    const edges: VconShapeGraphEdge[] = [];
+
+    const nodeId = (kind: VconShapeGraphNode['kind'], label: string) =>
+      `${kind}:${encodeURIComponent(label)}`;
+
+    const runSql = async (q: string) => {
+      const { data, error } = await this.supabase.rpc('exec_sql', { q, params: {} });
+      if (error) throw error;
+      return (data || []) as Record<string, unknown>[];
+    };
+
+    try {
+      const analysisRows = await runSql(`
+        SELECT type AS value, COUNT(DISTINCT vcon_id)::bigint AS vcon_count
+        FROM analysis
+        WHERE type IS NOT NULL AND btrim(type::text) <> ''
+        GROUP BY type
+        ORDER BY vcon_count DESC
+      `);
+      for (const row of analysisRows) {
+        const label = String(row.value ?? '').trim();
+        if (!label) continue;
+        nodes.push({
+          id: nodeId('analysis_type', label),
+          kind: 'analysis_type',
+          label,
+          vcon_count: Number(row.vcon_count ?? 0),
+        });
+      }
+
+      const purposeRows = await runSql(`
+        SELECT purpose AS value, COUNT(DISTINCT vcon_id)::bigint AS vcon_count
+        FROM attachments
+        WHERE purpose IS NOT NULL AND btrim(purpose::text) <> ''
+        GROUP BY purpose
+        ORDER BY vcon_count DESC
+      `);
+      for (const row of purposeRows) {
+        const label = String(row.value ?? '').trim();
+        if (!label) continue;
+        nodes.push({
+          id: nodeId('attachment_purpose', label),
+          kind: 'attachment_purpose',
+          label,
+          vcon_count: Number(row.vcon_count ?? 0),
+        });
+      }
+
+      const legacyTypeRows = await runSql(`
+        SELECT type AS value, COUNT(DISTINCT vcon_id)::bigint AS vcon_count
+        FROM attachments
+        WHERE type IS NOT NULL AND btrim(type::text) <> ''
+          AND (purpose IS NULL OR btrim(purpose::text) = '')
+        GROUP BY type
+        ORDER BY vcon_count DESC
+      `);
+      for (const row of legacyTypeRows) {
+        const label = String(row.value ?? '').trim();
+        if (!label) continue;
+        nodes.push({
+          id: nodeId('attachment_type_legacy', label),
+          kind: 'attachment_type_legacy',
+          label,
+          vcon_count: Number(row.vcon_count ?? 0),
+        });
+      }
+
+      try {
+        const tagRows = await runSql(`
+          SELECT key AS value, COUNT(DISTINCT vcon_id)::bigint AS vcon_count
+          FROM vcon_tags_mv,
+               LATERAL jsonb_each_text(tags) AS t(key, value)
+          GROUP BY key
+          ORDER BY vcon_count DESC
+        `);
+        for (const row of tagRows) {
+          const label = String(row.value ?? '').trim();
+          if (!label) continue;
+          nodes.push({
+            id: nodeId('tag_key', label),
+            kind: 'tag_key',
+            label,
+            vcon_count: Number(row.vcon_count ?? 0),
+          });
+        }
+      } catch (e: any) {
+        notes.push(
+          `Tag-key nodes skipped: ${e?.message || String(e)}. Ensure vcon_tags_mv is available.`,
+        );
+      }
+
+      let vcons_with_tags_mv: number | undefined;
+      try {
+        const tot = await runSql(
+          `SELECT COUNT(DISTINCT vcon_id)::integer AS n FROM vcon_tags_mv`,
+        );
+        vcons_with_tags_mv = Number((tot[0] as any)?.n ?? 0);
+      } catch {
+        /* optional */
+      }
+
+      const coRows = await runSql(`
+        SELECT a.type AS analysis_type,
+               att.purpose AS attachment_purpose,
+               COUNT(DISTINCT a.vcon_id)::bigint AS joint_vcons
+        FROM analysis a
+        INNER JOIN attachments att ON att.vcon_id = a.vcon_id
+        WHERE a.type IS NOT NULL AND btrim(a.type::text) <> ''
+          AND att.purpose IS NOT NULL AND btrim(att.purpose::text) <> ''
+        GROUP BY a.type, att.purpose
+        ORDER BY joint_vcons DESC
+        LIMIT 400
+      `);
+      for (const row of coRows) {
+        const at = String(row.analysis_type ?? '').trim();
+        const ap = String(row.attachment_purpose ?? '').trim();
+        if (!at || !ap) continue;
+        const src = nodeId('analysis_type', at);
+        const tgt = nodeId('attachment_purpose', ap);
+        edges.push({
+          id: `edge:analysis_type_with_attachment_purpose:${encodeURIComponent(at)}:${encodeURIComponent(ap)}`,
+          kind: 'analysis_type_with_attachment_purpose',
+          source: src,
+          target: tgt,
+          joint_vcon_count: Number(row.joint_vcons ?? 0),
+        });
+      }
+
+      return {
+        schema_version: VCON_SHAPE_GRAPH_SCHEMA_VERSION,
+        generated_at,
+        corpus: {
+          ...(vcons_with_tags_mv !== undefined ? { vcons_with_tags_mv } : {}),
+          notes,
+        },
+        nodes,
+        edges,
+      };
+    } catch (err: any) {
+      logWithContext('warn', 'getVconShapeGraph SQL path failed, using discovery fallbacks', {
+        message: err?.message || String(err),
+      });
+      notes.push(
+        `Primary path used exec_sql aggregations; failed (${err?.message || String(err)}). ` +
+          'Counts on analysis and attachment nodes may reflect row tallies, not distinct vCons.',
+      );
+
+      const analysis = await this.getUniqueAnalysisTypes({ includeCounts: true });
+      for (const v of analysis.values) {
+        nodes.push({
+          id: nodeId('analysis_type', v),
+          kind: 'analysis_type',
+          label: v,
+          ...(analysis.countsPerValue ? { vcon_count: analysis.countsPerValue[v] } : {}),
+        });
+      }
+      const purposes = await this.getUniqueAttachmentPurposes({ includeCounts: true });
+      for (const v of purposes.values) {
+        nodes.push({
+          id: nodeId('attachment_purpose', v),
+          kind: 'attachment_purpose',
+          label: v,
+          ...(purposes.countsPerValue ? { vcon_count: purposes.countsPerValue[v] } : {}),
+        });
+      }
+      const legacyTypes = await this.getUniqueAttachmentTypes({ includeCounts: true });
+      for (const v of legacyTypes.values) {
+        nodes.push({
+          id: nodeId('attachment_type_legacy', v),
+          kind: 'attachment_type_legacy',
+          label: v,
+          ...(legacyTypes.countsPerValue ? { vcon_count: legacyTypes.countsPerValue[v] } : {}),
+        });
+      }
+      const tags = await this.getUniqueTags({ includeCounts: true });
+      for (const k of tags.keys) {
+        let approx: number | undefined;
+        if (tags.countsPerValue?.[k]) {
+          approx = Object.values(tags.countsPerValue[k]).reduce((a, b) => a + b, 0);
+        }
+        nodes.push({
+          id: nodeId('tag_key', k),
+          kind: 'tag_key',
+          label: k,
+          ...(approx !== undefined ? { vcon_count: approx } : {}),
+        });
+      }
+
+      return {
+        schema_version: VCON_SHAPE_GRAPH_SCHEMA_VERSION,
+        generated_at,
+        corpus: {
+          vcons_with_tags_mv: tags.totalVCons,
+          notes,
+        },
+        nodes,
+        edges,
+      };
+    }
   }
 
   async aggregateVconsByDealerStats(params: {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -20,7 +20,7 @@ import { deserializeBody, serializeBody } from '../utils/body-serialization.js';
 
 const logger = createLogger('queries');
 
-import { IVConQueries } from './interfaces.js';
+import { DistinctValuesResult, IVConQueries } from './interfaces.js';
 
 export class SupabaseVConQueries implements IVConQueries {
   private redis: Redis | null = null;
@@ -527,6 +527,7 @@ export class SupabaseVConQueries implements IVConQueries {
         vcon_id: vcon.id,
         attachment_index: nextIndex,
         type: attachment.type,
+        purpose: attachment.purpose,
         start_time: attachment.start,
         party: attachment.party,
         dialog: attachment.dialog,            // ✅ Added per spec Section 4.4.4
@@ -725,6 +726,7 @@ export class SupabaseVConQueries implements IVConQueries {
         })),
         attachments: attachments?.map(att => ({
           type: att.type,
+          purpose: att.purpose,
           start: att.start_time,
           party: att.party,
           dialog: att.dialog,
@@ -767,6 +769,143 @@ export class SupabaseVConQueries implements IVConQueries {
     });
   }
 
+  private static readonly TAG_ORDERED_FETCH_CAP = 100_000;
+
+  private async filterVconUuidsBySubject(uuids: string[], subject: string): Promise<string[]> {
+    if (uuids.length === 0 || !subject) return uuids;
+    const ordered: string[] = [];
+    const IN_BATCH = 400;
+    for (let i = 0; i < uuids.length; i += IN_BATCH) {
+      const chunk = uuids.slice(i, i + IN_BATCH);
+      const { data, error } = await this.supabase
+        .from('vcons')
+        .select('uuid')
+        .in('uuid', chunk)
+        .ilike('subject', `%${subject}%`);
+      if (error) throw error;
+      const hit = new Set((data || []).map((r: { uuid: string }) => r.uuid));
+      for (const u of chunk) {
+        if (hit.has(u)) ordered.push(u);
+      }
+    }
+    return ordered;
+  }
+
+  private async partyMatchUuidSet(filters: {
+    partyName?: string;
+    partyEmail?: string;
+    partyTel?: string;
+  }): Promise<Set<string>> {
+    let partyQuery = this.supabase
+      .from('parties')
+      .select('vcon_id')
+      .limit(10000);
+
+    if (filters.partyName) {
+      partyQuery = partyQuery.ilike('name', `%${filters.partyName}%`);
+    }
+    if (filters.partyEmail) {
+      partyQuery = partyQuery.ilike('mailto', `%${filters.partyEmail}%`);
+    }
+    if (filters.partyTel) {
+      partyQuery = partyQuery.ilike('tel', `%${filters.partyTel}%`);
+    }
+
+    const { data: partyData, error: partyError } = await partyQuery;
+    if (partyError) throw partyError;
+    if (!partyData || partyData.length === 0) {
+      return new Set();
+    }
+
+    const partyVconIds = new Set(partyData.map(p => p.vcon_id));
+    const partyIdArray = Array.from(partyVconIds);
+    const IN_BATCH = 400;
+    const matchingUuidSet = new Set<string>();
+    for (let i = 0; i < partyIdArray.length; i += IN_BATCH) {
+      const chunk = partyIdArray.slice(i, i + IN_BATCH);
+      const { data: batchVcons } = await this.supabase
+        .from('vcons')
+        .select('uuid, id')
+        .in('id', chunk);
+      (batchVcons || []).forEach(v => matchingUuidSet.add(v.uuid));
+    }
+    return matchingUuidSet;
+  }
+
+  private async filterVconUuidsByPartyOrdered(
+    orderedUuids: string[],
+    filters: { partyName?: string; partyEmail?: string; partyTel?: string },
+  ): Promise<string[]> {
+    const partySet = await this.partyMatchUuidSet(filters);
+    if (partySet.size === 0) return [];
+    return orderedUuids.filter(u => partySet.has(u));
+  }
+
+  private async dealerMatchUuidSet(dealerId?: string, dealerName?: string): Promise<Set<string>> {
+    if (!dealerId && !dealerName) return new Set();
+    const { data, error } = await this.supabase.rpc('vcon_uuids_for_dealer_filter', {
+      p_dealer_id: dealerId ?? null,
+      p_name_ilike: dealerName ?? null,
+    });
+    if (error) throw error;
+    return new Set((data || []).map((r: { vcon_uuid: string }) => r.vcon_uuid));
+  }
+
+  private async filterVconUuidsByDealerOrdered(
+    orderedUuids: string[],
+    dealerId?: string,
+    dealerName?: string,
+  ): Promise<string[]> {
+    const dealerSet = await this.dealerMatchUuidSet(dealerId, dealerName);
+    if (dealerSet.size === 0) return [];
+    return orderedUuids.filter(u => dealerSet.has(u));
+  }
+
+  /**
+   * Tag-first metadata search: ordered by vcon.created_at via search_vcons_by_tags_and_date,
+   * then optional subject / party / dealer narrowing. Aligns pagination with searchVConsCount.
+   */
+  private async searchVConsTagOrdered(filters: {
+    subject?: string;
+    partyName?: string;
+    partyEmail?: string;
+    partyTel?: string;
+    startDate?: string;
+    endDate?: string;
+    tags: Record<string, string>;
+    dealerId?: string;
+    dealerName?: string;
+    limit?: number;
+  }, limit: number): Promise<VCon[]> {
+    const rpcMax = Math.min(
+      SupabaseVConQueries.TAG_ORDERED_FETCH_CAP,
+      Math.max(limit, 1),
+    );
+    let ordered = await this.searchByTagsAndDate(
+      filters.tags,
+      filters.startDate,
+      filters.endDate,
+      rpcMax,
+    );
+
+    if (filters.subject) {
+      ordered = await this.filterVconUuidsBySubject(ordered, filters.subject);
+    }
+    if (filters.partyName || filters.partyEmail || filters.partyTel) {
+      ordered = await this.filterVconUuidsByPartyOrdered(ordered, filters);
+    }
+    if (filters.dealerId || filters.dealerName) {
+      ordered = await this.filterVconUuidsByDealerOrdered(
+        ordered,
+        filters.dealerId,
+        filters.dealerName,
+      );
+    }
+
+    const vconUuids = ordered.slice(0, limit);
+    return Promise.all(vconUuids.map(uuid => this.getVCon(uuid)));
+  }
+
   /**
    * Search vCons by various criteria
    */
@@ -778,18 +917,35 @@ export class SupabaseVConQueries implements IVConQueries {
     startDate?: string;
     endDate?: string;
     tags?: Record<string, string>;
+    dealerId?: string;
+    dealerName?: string;
     limit?: number;
   }): Promise<VCon[]> {
     const limit = filters.limit || 10;
 
+    if (filters.tags && Object.keys(filters.tags).length > 0) {
+      return this.searchVConsTagOrdered(
+        {
+          subject: filters.subject,
+          partyName: filters.partyName,
+          partyEmail: filters.partyEmail,
+          partyTel: filters.partyTel,
+          startDate: filters.startDate,
+          endDate: filters.endDate,
+          tags: filters.tags,
+          dealerId: filters.dealerId,
+          dealerName: filters.dealerName,
+          limit: filters.limit,
+        },
+        limit,
+      );
+    }
+
     // Start with party filters if present - these constrain which vCons to consider
     // Party filters must be applied FIRST to avoid missing results due to limit
-    let candidateVconIds: Set<number> | null = null;
+    let candidateVconIds: Set<string> | null = null;
 
     if (filters.partyName || filters.partyEmail || filters.partyTel) {
-      // Explicit limit (PostgREST default cap is typically 1000 rows, which
-      // can silently truncate a name/email filter before it reaches the
-      // specific vCon the caller was looking for).
       let partyQuery = this.supabase
         .from('parties')
         .select('vcon_id')
@@ -809,20 +965,14 @@ export class SupabaseVConQueries implements IVConQueries {
       if (partyError) throw partyError;
 
       if (!partyData || partyData.length === 0) {
-        // No parties match - return empty result
         return [];
       }
 
-      candidateVconIds = new Set(partyData.map(p => p.vcon_id));
+      candidateVconIds = new Set(partyData.map(p => String(p.vcon_id)));
     }
 
-    // If we have tag filters, fetch more initially to allow for filtering.
-    const initialLimit = (filters.tags && Object.keys(filters.tags).length > 0)
-      ? Math.max(limit * 10, 1000)
-      : limit;
+    const initialLimit = limit;
 
-    // Common per-query filter application. Shared by the single-shot and the
-    // batched-IN code paths so both honor the same subject/date filters.
     const applyFilters = <Q extends { ilike: any; gte: any; lte: any; order: any; limit: any }>(
       q: Q,
       withLimit: boolean,
@@ -841,10 +991,6 @@ export class SupabaseVConQueries implements IVConQueries {
 
     try {
       if (candidateVconIds !== null) {
-        // Batched path. The party-match set may be arbitrarily large; PostgREST
-        // encodes `.in()` into the URL so 400 UUIDs is the safe ceiling. Walk
-        // the full candidate set in chunks, then sort/limit in JS to produce
-        // the same top-N-by-created_at ordering as the single-shot path below.
         const idArray = Array.from(candidateVconIds);
         const IN_BATCH = 100;
         const accumulated: Array<{ uuid: string; id: any; created_at: string }> = [];
@@ -892,61 +1038,17 @@ export class SupabaseVConQueries implements IVConQueries {
     let vconUuids = data.map(v => v.uuid);
 
     if (filters.partyName || filters.partyEmail || filters.partyTel) {
-      // Same explicit limit rationale as the pre-filter block above — avoid
-      // silent PostgREST row truncation when names/emails match many rows.
-      let partyQuery = this.supabase
-        .from('parties')
-        .select('vcon_id')
-        .limit(10000);
-
-      if (filters.partyName) {
-        partyQuery = partyQuery.ilike('name', `%${filters.partyName}%`);
-      }
-      if (filters.partyEmail) {
-        partyQuery = partyQuery.ilike('mailto', `%${filters.partyEmail}%`);
-      }
-      if (filters.partyTel) {
-        partyQuery = partyQuery.ilike('tel', `%${filters.partyTel}%`);
-      }
-
-      const { data: partyData, error: partyError } = await partyQuery;
-      if (partyError) throw partyError;
-
-      const partyVconIds = new Set(partyData.map(p => p.vcon_id));
-
-      // Batch the .in() to avoid "URI too long" when partyVconIds is large.
-      // PostgREST encodes .in() as a URL parameter; arrays > ~400 items can
-      // exceed HTTP header/URL size limits.
-      const partyIdArray = Array.from(partyVconIds);
-      const IN_BATCH = 400;
-      const matchingUuidSet = new Set<string>();
-      for (let i = 0; i < partyIdArray.length; i += IN_BATCH) {
-        const chunk = partyIdArray.slice(i, i + IN_BATCH);
-        const { data: batchVcons } = await this.supabase
-          .from('vcons')
-          .select('uuid, id')
-          .in('id', chunk);
-        (batchVcons || []).forEach(v => matchingUuidSet.add(v.uuid));
-      }
-
+      const matchingUuidSet = await this.partyMatchUuidSet(filters);
       vconUuids = vconUuids.filter(uuid => matchingUuidSet.has(uuid));
     }
 
-    // If tag filters, get matching UUIDs and intersect with current results.
-    // Use the date-aware RPC when a date range is set so we don't intersect
-    // an undated 10k-UUID list against a date-truncated candidate set.
-    if (filters.tags && Object.keys(filters.tags).length > 0) {
-      const tagMatchingUuids = (filters.startDate || filters.endDate)
-        ? await this.searchByTagsAndDate(filters.tags, filters.startDate, filters.endDate, 100000)
-        : await this.searchByTags(filters.tags, 10000);
-      const tagMatchingSet = new Set(tagMatchingUuids);
-      vconUuids = vconUuids.filter(uuid => tagMatchingSet.has(uuid));
+    if (filters.dealerId || filters.dealerName) {
+      const dealerSet = await this.dealerMatchUuidSet(filters.dealerId, filters.dealerName);
+      vconUuids = vconUuids.filter(uuid => dealerSet.has(uuid));
     }
 
-    // Apply final limit after all filtering
     vconUuids = vconUuids.slice(0, limit);
 
-    // Fetch full vCons
     return Promise.all(
       vconUuids.map(uuid => this.getVCon(uuid))
     );
@@ -964,7 +1066,25 @@ export class SupabaseVConQueries implements IVConQueries {
     startDate?: string;
     endDate?: string;
     tags?: Record<string, string>;
+    dealerId?: string;
+    dealerName?: string;
   }): Promise<number> {
+    const hasTags = !!(filters.tags && Object.keys(filters.tags).length > 0);
+    const hasParty = !!(filters.partyName || filters.partyEmail || filters.partyTel);
+    const hasDealer = !!(filters.dealerId || filters.dealerName);
+
+    if (hasDealer && !hasTags && !hasParty) {
+      const { data, error } = await this.supabase.rpc('count_vcons_for_dealer_filter', {
+        p_dealer_id: filters.dealerId ?? null,
+        p_name_ilike: filters.dealerName ?? null,
+        p_subject_contains: filters.subject ?? null,
+        vcon_created_after: filters.startDate ?? null,
+        vcon_created_before: filters.endDate ?? null,
+      });
+      if (error) throw error;
+      return typeof data === 'number' ? data : Number(data ?? 0);
+    }
+
     // Build the same query as searchVCons but just get count
     let query = this.supabase
       .from('vcons')
@@ -1041,6 +1161,9 @@ export class SupabaseVConQueries implements IVConQueries {
           100000,
         );
         const tagAndDateSet = new Set(tagAndDateUuids);
+        const dealerSet = (filters.dealerId || filters.dealerName)
+          ? await this.dealerMatchUuidSet(filters.dealerId, filters.dealerName)
+          : null;
 
         const partyIdArray = Array.from(partyVconIds);
         const IN_BATCH = 400;
@@ -1051,7 +1174,9 @@ export class SupabaseVConQueries implements IVConQueries {
           if (filters.subject) chunkQuery = chunkQuery.ilike('subject', `%${filters.subject}%`);
           const { data: batchVcons } = await chunkQuery;
           for (const v of batchVcons || []) {
-            if (tagAndDateSet.has(v.uuid)) matched++;
+            if (!tagAndDateSet.has(v.uuid)) continue;
+            if (dealerSet && !dealerSet.has(v.uuid)) continue;
+            matched++;
           }
         }
         return matched;
@@ -1064,8 +1189,19 @@ export class SupabaseVConQueries implements IVConQueries {
     // so it executes as a single SQL join instead of a JS intersection over
     // a PostgREST page-truncated result set.
     if (filters.tags && Object.keys(filters.tags).length > 0) {
-      // Subject filter is rare in this path; if present we have to fall back
-      // to UUID intersection because the RPC doesn't accept it.
+      if (!hasParty && (filters.dealerId || filters.dealerName)) {
+        const { data, error } = await this.supabase.rpc('count_vcons_tags_and_dealer', {
+          tag_filter: filters.tags,
+          p_dealer_id: filters.dealerId ?? null,
+          p_name_ilike: filters.dealerName ?? null,
+          vcon_created_after: filters.startDate ?? null,
+          vcon_created_before: filters.endDate ?? null,
+          p_subject_contains: filters.subject ?? null,
+        });
+        if (error) throw error;
+        return typeof data === 'number' ? data : Number(data ?? 0);
+      }
+
       if (filters.subject) {
         const tagAndDateUuids = await this.searchByTagsAndDate(
           filters.tags,
@@ -1076,7 +1212,6 @@ export class SupabaseVConQueries implements IVConQueries {
         if (tagAndDateUuids.length === 0) return 0;
         const tagAndDateSet = new Set(tagAndDateUuids);
 
-        // Walk vcons in batches matching the subject filter and intersect.
         const uuidArray = Array.from(tagAndDateSet);
         const IN_BATCH = 400;
         let matched = 0;
@@ -1118,11 +1253,6 @@ export class SupabaseVConQueries implements IVConQueries {
     if (error) throw error;
     return count || 0;
   }
-
-  /**
-   * Delete a vCon and all related entities
-   */
-
 
   /**
    * Update vCon metadata
@@ -1477,6 +1607,131 @@ export class SupabaseVConQueries implements IVConQueries {
   }
 
   /**
+   * Get distinct string values from a table column with optional counts.
+   * Uses exec_sql when available, then falls back to a JS batch scan.
+   */
+  private async getDistinctValues(
+    table: 'attachments' | 'analysis',
+    column: 'type' | 'purpose',
+    options?: {
+      includeCounts?: boolean;
+      minCount?: number;
+    },
+  ): Promise<DistinctValuesResult> {
+    const includeCounts = options?.includeCounts ?? false;
+    const minCount = options?.minCount ?? 1;
+
+    try {
+      const havingClause = minCount > 1 ? `HAVING COUNT(*) >= ${minCount}` : '';
+      const aggQuery = `
+        SELECT ${column} AS value, COUNT(*)::integer AS cnt
+        FROM ${table}
+        WHERE ${column} IS NOT NULL
+          AND btrim(${column}) <> ''
+        GROUP BY ${column}
+        ${havingClause}
+        ORDER BY cnt DESC, ${column} ASC
+      `;
+      const totalQuery = `
+        SELECT COUNT(DISTINCT vcon_id)::integer AS total
+        FROM ${table}
+        WHERE ${column} IS NOT NULL
+          AND btrim(${column}) <> ''
+      `;
+
+      const [{ data: rows, error: rowsErr }, { data: totalData, error: totalErr }] = await Promise.all([
+        this.supabase.rpc('exec_sql', { q: aggQuery, params: {} }),
+        this.supabase.rpc('exec_sql', { q: totalQuery, params: {} }),
+      ]);
+
+      if (rowsErr) throw rowsErr;
+      if (totalErr) throw totalErr;
+
+      const values: string[] = [];
+      const countsPerValue: Record<string, number> = {};
+      for (const row of rows || []) {
+        const value = typeof row?.value === 'string' ? row.value.trim() : '';
+        if (!value) continue;
+        values.push(value);
+        if (includeCounts) {
+          countsPerValue[value] = Number(row?.cnt || 0);
+        }
+      }
+
+      return {
+        values,
+        ...(includeCounts ? { countsPerValue } : {}),
+        totalVCons: Number((totalData as any)?.[0]?.total ?? 0),
+      };
+    } catch (fastErr: any) {
+      const isExpected =
+        fastErr?.code === '42P01' ||
+        fastErr?.code === 'PGRST202' ||
+        fastErr?.message?.includes('does not exist') ||
+        fastErr?.message?.includes('Could not find');
+      if (!isExpected) throw fastErr;
+      logWithContext('warn', 'Distinct-values SQL fast path unavailable, using JS batch fallback', {
+        table,
+        column,
+        reason: fastErr.message,
+      });
+    }
+
+    const { count, error: countError } = await this.supabase
+      .from(table)
+      .select('*', { count: 'exact', head: true });
+    if (countError) throw countError;
+
+    const batchSize = 1000;
+    const totalBatches = Math.ceil((count || 0) / batchSize);
+    const valuesSet = new Set<string>();
+    const countsPerValue: Record<string, number> = {};
+    const vconIds = new Set<string>();
+
+    for (let i = 0; i < totalBatches; i++) {
+      const from = i * batchSize;
+      const to = Math.min(from + batchSize - 1, (count || 0) - 1);
+      const { data: batch, error } = await this.supabase
+        .from(table)
+        .select(`vcon_id, ${column}`)
+        .range(from, to);
+      if (error) throw error;
+
+      for (const row of batch || []) {
+        const record = row as Record<string, unknown>;
+        const raw = record[column];
+        const value = typeof raw === 'string' ? raw.trim() : '';
+        if (!value) continue;
+        valuesSet.add(value);
+        countsPerValue[value] = (countsPerValue[value] || 0) + 1;
+        if (record.vcon_id) {
+          vconIds.add(String(record.vcon_id));
+        }
+      }
+    }
+
+    const values = Array.from(valuesSet)
+      .filter((value) => countsPerValue[value] >= minCount)
+      .sort((a, b) => {
+        const countDiff = countsPerValue[b] - countsPerValue[a];
+        return countDiff !== 0 ? countDiff : a.localeCompare(b);
+      });
+
+    const filteredCounts: Record<string, number> = {};
+    if (includeCounts) {
+      for (const value of values) {
+        filteredCounts[value] = countsPerValue[value];
+      }
+    }
+
+    return {
+      values,
+      ...(includeCounts ? { countsPerValue: filteredCounts } : {}),
+      totalVCons: vconIds.size,
+    };
+  }
+
+  /**
    * Get unique tags across all vCons
    */
   async getUniqueTags(options?: {
@@ -1653,6 +1908,105 @@ export class SupabaseVConQueries implements IVConQueries {
     };
     if (includeCounts) result.countsPerValue = filteredCounts;
     return result;
+  }
+
+  async getUniqueAttachmentTypes(options?: {
+    includeCounts?: boolean;
+    minCount?: number;
+  }): Promise<DistinctValuesResult> {
+    return this.getDistinctValues('attachments', 'type', options);
+  }
+
+  async getUniqueAttachmentPurposes(options?: {
+    includeCounts?: boolean;
+    minCount?: number;
+  }): Promise<DistinctValuesResult> {
+    return this.getDistinctValues('attachments', 'purpose', options);
+  }
+
+  async getUniqueAnalysisTypes(options?: {
+    includeCounts?: boolean;
+    minCount?: number;
+  }): Promise<DistinctValuesResult> {
+    return this.getDistinctValues('analysis', 'type', options);
+  }
+
+  async aggregateVconsByDealerStats(params: {
+    tagFilter: Record<string, string>;
+    startDate?: string;
+    endDate?: string;
+    minBaseline: number;
+    limit: number;
+  }): Promise<Array<{
+    dealer_id: string;
+    dealer_name: string | null;
+    team_id: number | null;
+    team_name: string | null;
+    filtered_count: number;
+    baseline_count: number;
+  }>> {
+    const { data, error } = await this.supabase.rpc('aggregate_vcons_by_dealer_stats', {
+      tag_filter: params.tagFilter,
+      vcon_created_after: params.startDate ?? null,
+      vcon_created_before: params.endDate ?? null,
+      min_baseline: params.minBaseline,
+      max_results: params.limit,
+    });
+    if (error) throw error;
+    return (data || []).map((row: Record<string, unknown>) => ({
+      dealer_id: String(row.dealer_id ?? ''),
+      dealer_name: (row.dealer_name as string) ?? null,
+      team_id: row.team_id != null ? Number(row.team_id) : null,
+      team_name: (row.team_name as string) ?? null,
+      filtered_count: Number(row.filtered_count ?? 0),
+      baseline_count: Number(row.baseline_count ?? 0),
+    }));
+  }
+
+  async getTaxonomyCoverageSnapshot(): Promise<{
+    vcons_total: number | null;
+    with_strolid_dealer_attachment_pct: number | null;
+    with_dealer_name_tag_pct: number | null;
+  }> {
+    const none = {
+      vcons_total: null as number | null,
+      with_strolid_dealer_attachment_pct: null as number | null,
+      with_dealer_name_tag_pct: null as number | null,
+    };
+    try {
+      const { count: totalV, error: e1 } = await this.supabase
+        .from('vcons')
+        .select('*', { count: 'exact', head: true });
+      if (e1 || totalV == null || totalV === 0) return none;
+
+      const { count: dealerRows, error: e2 } = await this.supabase
+        .from('attachments')
+        .select('vcon_id', { count: 'exact', head: true })
+        .eq('type', 'strolid_dealer');
+      if (e2) return { ...none, vcons_total: totalV };
+
+      const dealerPct = Math.min(
+        100,
+        Math.round(((dealerRows ?? 0) / totalV) * 1000) / 10,
+      );
+
+      let dealerNamePct: number | null = null;
+      const { count: nameTagRows, error: e3 } = await this.supabase
+        .from('vcon_tags_mv')
+        .select('*', { count: 'exact', head: true })
+        .not('tags->dealer_name', 'is', null);
+      if (!e3 && nameTagRows != null) {
+        dealerNamePct = Math.min(100, Math.round((nameTagRows / totalV) * 1000) / 10);
+      }
+
+      return {
+        vcons_total: totalV,
+        with_strolid_dealer_attachment_pct: dealerPct,
+        with_dealer_name_tag_pct: dealerNamePct,
+      };
+    } catch {
+      return none;
+    }
   }
 
   /**

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -17,7 +17,13 @@
  */
 
 import { IVConQueries } from '../db/interfaces.js';
-import { deserializeBody } from '../utils/body-serialization.js';
+import {
+  extractTags,
+  filterAnalysis,
+  filterAttachments,
+  getVConMetadata,
+  toDiscoveryValues,
+} from '../utils/read-surfaces.js';
 
 export interface ResourceDescriptor {
   uri: string;
@@ -87,6 +93,53 @@ export function getCoreResources(): ResourceDescriptor[] {
       description: 'Retrieve only the attachments array from a vCon. Returns all attached files and metadata.',
       mimeType: 'application/json' 
     },
+
+    // Discovery resources
+    {
+      uri: 'vcon://v1/discovery/attachments/types',
+      name: 'Discover legacy attachment types',
+      description: 'List discovered legacy attachment type values across the database, with counts. Prefer attachment purposes for spec-compliant discovery; use types only for compatibility with older datasets.',
+      mimeType: 'application/json'
+    },
+    {
+      uri: 'vcon://v1/discovery/attachments/purposes',
+      name: 'Discover attachment purposes',
+      description: 'List discovered attachment purpose values across the database, with counts. This is the canonical spec-facing attachment classification surface; prefer it before tags or legacy attachment types.',
+      mimeType: 'application/json'
+    },
+    {
+      uri: 'vcon://v1/discovery/analysis/types',
+      name: 'Discover analysis types',
+      description: 'List discovered analysis type values across the database, with counts. Use this before reading a vCon by analysis type.',
+      mimeType: 'application/json'
+    },
+    {
+      uri: 'vcon://v1/graph/shape',
+      name: 'vCon shape graph (OSS)',
+      description:
+        'Default corpus-level graph from vCon structure only: analysis types, attachment purposes, legacy attachment types without purpose, tag keys, and bounded co-occurrence edges (analysis type with attachment purpose). No business ontology. Prefer this resource after vcon_capabilities when teaching an LLM what evidence exists in the corpus.',
+      mimeType: 'application/json'
+    },
+
+    // Generic filtered resources
+    {
+      uri: 'vcon://v1/vcons/{uuid}/attachments/type/{type}',
+      name: 'Get attachments by legacy type',
+      description: 'Retrieve attachments on a vCon filtered by legacy attachment type. Prefer the purpose-based resource for spec-compliant clients and use this type-based path only for compatibility with older data.',
+      mimeType: 'application/json'
+    },
+    {
+      uri: 'vcon://v1/vcons/{uuid}/attachments/purpose/{purpose}',
+      name: 'Get attachments by purpose',
+      description: 'Retrieve attachments on a vCon filtered by attachment purpose. This is the canonical spec-facing attachment read path; replace {purpose} with a discovered attachment purpose value.',
+      mimeType: 'application/json'
+    },
+    {
+      uri: 'vcon://v1/vcons/{uuid}/analysis/type/{type}',
+      name: 'Get analysis by type',
+      description: 'Retrieve analysis entries on a vCon filtered by analysis type. Replace {type} with a discovered analysis type value.',
+      mimeType: 'application/json'
+    },
     
     // Derived resources
     { 
@@ -112,6 +165,35 @@ export function getCoreResources(): ResourceDescriptor[] {
 
 export async function resolveCoreResource(queries: IVConQueries, uri: string): Promise<{ mimeType: string; content: any } | undefined> {
   const json = (data: any) => ({ mimeType: 'application/json', content: data });
+
+  if (uri === 'vcon://v1/discovery/attachments/types') {
+    const result = await queries.getUniqueAttachmentTypes({ includeCounts: true });
+    return json({
+      count: result.values.length,
+      attachment_types: toDiscoveryValues(result),
+    });
+  }
+
+  if (uri === 'vcon://v1/discovery/attachments/purposes') {
+    const result = await queries.getUniqueAttachmentPurposes({ includeCounts: true });
+    return json({
+      count: result.values.length,
+      attachment_purposes: toDiscoveryValues(result),
+    });
+  }
+
+  if (uri === 'vcon://v1/discovery/analysis/types') {
+    const result = await queries.getUniqueAnalysisTypes({ includeCounts: true });
+    return json({
+      count: result.values.length,
+      analysis_types: toDiscoveryValues(result),
+    });
+  }
+
+  if (uri === 'vcon://v1/graph/shape') {
+    const graph = await queries.getVconShapeGraph();
+    return json(graph);
+  }
 
   // Handle recent vCons (full data)
   const matchRecent = uri.match(/^vcon:\/\/v1\/vcons\/recent(?:\/(\d+))?$/);
@@ -194,8 +276,7 @@ export async function resolveCoreResource(queries: IVConQueries, uri: string): P
 
   // Metadata (excludes arrays)
   if (suffix === '/metadata') {
-    const { parties, dialog, analysis, attachments, ...meta } = vcon as any;
-    return json(meta);
+    return json(getVConMetadata(vcon));
   }
 
   // Subresources - return specific arrays
@@ -215,9 +296,42 @@ export async function resolveCoreResource(queries: IVConQueries, uri: string): P
     return json({ attachments: vcon.attachments || [] });
   }
 
+  const matchAttachmentType = suffix.match(/^\/attachments\/type\/(.+)$/);
+  if (matchAttachmentType) {
+    const type = decodeURIComponent(matchAttachmentType[1]);
+    const attachments = filterAttachments(vcon, { type });
+    return json({
+      count: attachments.length,
+      type,
+      attachments,
+    });
+  }
+
+  const matchAttachmentPurpose = suffix.match(/^\/attachments\/purpose\/(.+)$/);
+  if (matchAttachmentPurpose) {
+    const purpose = decodeURIComponent(matchAttachmentPurpose[1]);
+    const attachments = filterAttachments(vcon, { purpose });
+    return json({
+      count: attachments.length,
+      purpose,
+      attachments,
+    });
+  }
+
+  const matchAnalysisType = suffix.match(/^\/analysis\/type\/(.+)$/);
+  if (matchAnalysisType) {
+    const type = decodeURIComponent(matchAnalysisType[1]);
+    const analysis = filterAnalysis(vcon, { type });
+    return json({
+      count: analysis.length,
+      type,
+      analysis,
+    });
+  }
+
   // Derived resources - filter by type
   if (suffix === '/transcript') {
-    const transcripts = (vcon.analysis || []).filter(a => a.type === 'transcript');
+    const transcripts = filterAnalysis(vcon, { type: 'transcript' });
     return json({ 
       count: transcripts.length,
       transcripts: transcripts 
@@ -225,7 +339,7 @@ export async function resolveCoreResource(queries: IVConQueries, uri: string): P
   }
 
   if (suffix === '/summary') {
-    const summaries = (vcon.analysis || []).filter(a => a.type === 'summary');
+    const summaries = filterAnalysis(vcon, { type: 'summary' });
     return json({ 
       count: summaries.length,
       summaries: summaries 
@@ -233,30 +347,7 @@ export async function resolveCoreResource(queries: IVConQueries, uri: string): P
   }
 
   if (suffix === '/tags') {
-    const tagsAttachment = (vcon.attachments || []).find(a => a.type === 'tags');
-    if (!tagsAttachment || !tagsAttachment.body) {
-      return json({ tags: {} });
-    }
-    
-    try {
-      const tagsArray = JSON.parse(tagsAttachment.body as string) as string[];
-      const tagsObject: Record<string, string> = {};
-      
-      for (const tagString of tagsArray) {
-        if (typeof tagString !== 'string') continue;
-        const colonIndex = tagString.indexOf(':');
-        if (colonIndex === -1) continue;
-        
-        const key = tagString.substring(0, colonIndex);
-        const value = tagString.substring(colonIndex + 1);
-        tagsObject[key] = value;
-      }
-      
-      return json({ tags: tagsObject });
-    } catch (error) {
-      // If parsing fails, return empty tags
-      return json({ tags: {} });
-    }
+    return json({ tags: extractTags(vcon) });
   }
 
   // Unknown subresource

--- a/src/tools/handlers/index.ts
+++ b/src/tools/handlers/index.ts
@@ -35,6 +35,7 @@ import {
   VConCapabilitiesHandler,
   VConSearchHandler,
   VConTaxonomyHandler,
+  VConAggregateHandler,
   DescribeResponseShapeHandler,
 } from './vcon-contract.js';
 
@@ -101,6 +102,7 @@ export function createHandlerRegistry(): ToolHandlerRegistry {
   registry.register(new VConCapabilitiesHandler());
   registry.register(new VConSearchHandler());
   registry.register(new VConTaxonomyHandler());
+  registry.register(new VConAggregateHandler());
   registry.register(new DescribeResponseShapeHandler());
 
   // Register tag handlers

--- a/src/tools/handlers/index.ts
+++ b/src/tools/handlers/index.ts
@@ -33,6 +33,7 @@ import {
 import {
   VConFetchHandler,
   VConCapabilitiesHandler,
+  VConGraphShapeHandler,
   VConSearchHandler,
   VConTaxonomyHandler,
   VConAggregateHandler,
@@ -100,6 +101,7 @@ export function createHandlerRegistry(): ToolHandlerRegistry {
   // Register redesigned contract handlers
   registry.register(new VConFetchHandler());
   registry.register(new VConCapabilitiesHandler());
+  registry.register(new VConGraphShapeHandler());
   registry.register(new VConSearchHandler());
   registry.register(new VConTaxonomyHandler());
   registry.register(new VConAggregateHandler());

--- a/src/tools/handlers/vcon-contract.ts
+++ b/src/tools/handlers/vcon-contract.ts
@@ -25,6 +25,7 @@ const DEFAULT_SEARCH_INCLUDES: FetchInclude[] = ['core', 'summary'];
 const DEFAULT_MAX_RESPONSE_BYTES = 250_000;
 const MIN_MAX_RESPONSE_BYTES = 1024;
 const SUPPORTED_SEARCH_MODES: SearchMode[] = ['metadata', 'keyword', 'semantic', 'hybrid'];
+const TAG_SORTED_WINDOW = 100_000;
 
 type CursorPayload = {
   offset: number;
@@ -72,15 +73,25 @@ function validateSearchMode(value: unknown): SearchMode {
 }
 
 function pickSummaryAnalysis(analysis: Analysis[] | undefined) {
-  return (analysis || []).filter((entry) => entry.type === 'summary').map((entry) => ({
-    type: entry.type,
-    vendor: entry.vendor,
-    product: entry.product,
-    schema: entry.schema,
-    encoding: entry.encoding,
-    body: entry.body,
-    dialog: entry.dialog,
-  }));
+  return (analysis || [])
+    .filter((entry) => entry.type === 'summary')
+    .map((entry) => ({
+      type: entry.type,
+      vendor: entry.vendor,
+      product: entry.product,
+      schema: entry.schema,
+      encoding: entry.encoding,
+      ...(typeof entry.body === 'string' && entry.body.trim().length > 0 ? { body: entry.body } : {}),
+      dialog: entry.dialog,
+    }));
+}
+
+function normalizeDealerTeam(raw: unknown): Record<string, unknown> | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const o = raw as Record<string, unknown>;
+  if (Object.keys(o).length === 0) return null;
+  return o;
 }
 
 function extractDealer(attachments: Attachment[] | undefined) {
@@ -101,11 +112,15 @@ function extractDealer(attachments: Attachment[] | undefined) {
   }
 
   const dealer = raw as Record<string, unknown>;
+  const idRaw = dealer.id;
+  const idNormalized =
+    idRaw === null || idRaw === undefined ? null : String(idRaw);
+
   return {
-    id: dealer.id ?? null,
+    id: idNormalized,
     name: dealer.name ?? null,
     outboundPhoneNumber: dealer.outboundPhoneNumber ?? null,
-    team: dealer.team ?? null,
+    team: normalizeDealerTeam(dealer.team),
   };
 }
 
@@ -320,7 +335,7 @@ const SHAPE_DESCRIPTORS: Record<string, ShapeDescriptor> = {
     example: {
       ok: true,
       item: {
-        tools: ['vcon_fetch', 'vcon_search', 'vcon_taxonomy', 'describe_response_shape'],
+        tools: ['vcon_fetch', 'vcon_search', 'vcon_taxonomy', 'vcon_aggregate', 'describe_response_shape'],
         response_budgeting: {
           default_max_response_bytes: 250000,
           minimum_max_response_bytes: 1024,
@@ -369,6 +384,10 @@ const SHAPE_DESCRIPTORS: Record<string, ShapeDescriptor> = {
           properties: {
             count: { type: 'number' },
             total: { type: 'number' },
+            iterable_total: {
+              type: 'number',
+              description: 'When present, maximum number of rows reachable via cursor for tag-sorted metadata search (newest TAG_SORTED_WINDOW matches).',
+            },
             next_cursor: { type: ['string', 'null'] },
           }
         }
@@ -388,10 +407,10 @@ const SHAPE_DESCRIPTORS: Record<string, ShapeDescriptor> = {
             }
           ],
           dealer: {
-            id: 'dealer-42',
+            id: '42',
             name: 'Acme Motors',
             outboundPhoneNumber: '+15551234567',
-            team: 'west'
+            team: { id: 8, name: 'Purple Team' },
           },
           search: {
             mode: 'keyword',
@@ -408,8 +427,58 @@ const SHAPE_DESCRIPTORS: Record<string, ShapeDescriptor> = {
     },
     notes: [
       'Cursor is opaque. Pass page.next_cursor back unchanged.',
-      'Counts are authoritative for metadata and keyword modes. Semantic and hybrid currently omit total.',
+      'For metadata search with tags, page.total is the full matching count while page.iterable_total may cap how far cursors can walk.',
+      'When items.length < limit, meta.short_page_reason explains whether more pages exist.',
+      'Semantic and hybrid modes omit page.total today.',
     ],
+  },
+  vcon_aggregate: {
+    tool_name: 'vcon_aggregate',
+    summary: 'Dealer-level rollups with optional tag numerator and baseline denominator for rate-style analytics.',
+    response_schema: {
+      type: 'object',
+      required: ['ok', 'item'],
+      properties: {
+        ok: { type: 'boolean', const: true },
+        item: {
+          type: 'object',
+          required: ['group_by', 'rows'],
+          properties: {
+            group_by: { type: 'string', const: 'dealer' },
+            rows: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  dealer_id: { type: 'string' },
+                  dealer_name: { type: ['string', 'null'] },
+                  team_id: { type: ['integer', 'null'] },
+                  team_name: { type: ['string', 'null'] },
+                  filtered_count: { type: 'number' },
+                  baseline_count: { type: 'number' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    example: {
+      ok: true,
+      item: {
+        group_by: 'dealer',
+        rows: [
+          {
+            dealer_id: '1174',
+            dealer_name: 'Example Motors',
+            team_id: 8,
+            team_name: 'Purple Team',
+            filtered_count: 42,
+            baseline_count: 600,
+          },
+        ],
+      },
+    },
   },
   describe_response_shape: {
     tool_name: 'describe_response_shape',
@@ -681,7 +750,7 @@ export class VConCapabilitiesHandler extends BaseToolHandler {
 
   protected async execute(_args: any, _context: ToolHandlerContext): Promise<ToolResponse> {
     return this.createOkItemResponse({
-      tools: ['vcon_fetch', 'vcon_capabilities', 'vcon_search', 'vcon_taxonomy', 'describe_response_shape'],
+      tools: ['vcon_fetch', 'vcon_capabilities', 'vcon_search', 'vcon_taxonomy', 'vcon_aggregate', 'describe_response_shape'],
       response_budgeting: {
         default_max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
         minimum_max_response_bytes: MIN_MAX_RESPONSE_BYTES,
@@ -713,7 +782,14 @@ export class VConCapabilitiesHandler extends BaseToolHandler {
         strategy: 'opaque cursor',
         request_field: 'cursor',
         response_field: 'page.next_cursor',
-        semantics: 'Pass page.next_cursor back unchanged. Do not try to interpret or edit it client-side.',
+        semantics:
+          'Pass page.next_cursor back unchanged. Do not try to interpret or edit it client-side. ' +
+          'For debugging only, cursors are currently base64url JSON with an offset field; production clients must still treat them as opaque.',
+        total_semantics:
+          'page.total is the database count for the same filter predicate as the search (including tags and dealer filters). ' +
+          'For tag-sorted metadata search, at most the newest ' +
+          String(TAG_SORTED_WINDOW) +
+          ' matching vCons are reachable via cursor pagination; when the corpus exceeds that window, page.iterable_total duplicates that cap so clients know pagination cannot walk the full total.',
       },
       taxonomy_hints: {
         preferred_bad_call_signals: ['negative_experience', 'dnc_request', 'bad_call_quality'],
@@ -765,6 +841,8 @@ export class VConSearchHandler extends BaseToolHandler {
       startDate: normalizeDateString(args?.filters?.start_date as string | undefined),
       endDate: normalizeDateString(args?.filters?.end_date as string | undefined),
       tags,
+      dealerId: args?.filters?.dealer_id != null ? String(args.filters.dealer_id) : undefined,
+      dealerName: args?.filters?.dealer_name as string | undefined,
     };
     const query = args?.query as string | undefined;
     const threshold = (args?.threshold as number | undefined) ?? 0.7;
@@ -783,7 +861,11 @@ export class VConSearchHandler extends BaseToolHandler {
         });
         const pageResults = results.slice(cursor.offset, cursor.offset + limit);
         total = await context.queries.searchVConsCount(filters);
-        hasNextPage = total > cursor.offset + pageResults.length;
+        const effectiveUpper =
+          tags && total !== undefined
+            ? Math.min(total, TAG_SORTED_WINDOW)
+            : total ?? 0;
+        hasNextPage = total !== undefined && effectiveUpper > cursor.offset + pageResults.length;
         items = await Promise.all(pageResults.map((vcon) => buildItem(context, vcon, include, {
           search: { mode: 'metadata' },
         })));
@@ -914,11 +996,24 @@ export class VConSearchHandler extends BaseToolHandler {
         }));
       }
 
-      const page = {
+      const page: Record<string, unknown> = {
         count: items.length,
         ...(total !== undefined ? { total } : {}),
+        ...(mode === 'metadata' && tags && total !== undefined && total > TAG_SORTED_WINDOW
+          ? { iterable_total: TAG_SORTED_WINDOW }
+          : {}),
         next_cursor: hasNextPage ? encodeCursor({ offset: cursor.offset + limit }) : null,
       };
+
+      let shortPageReason: string | undefined;
+      if (items.length < limit) {
+        if (mode === 'keyword' && hasNextPage) {
+          shortPageReason = 'keyword_dedup_or_rank_window';
+        } else {
+          shortPageReason = hasNextPage ? 'below_limit_more_results_exist' : 'end_of_searchable_results';
+        }
+      }
+
       const approximateBytes = estimateBytes({
         ok: true,
         items,
@@ -928,6 +1023,7 @@ export class VConSearchHandler extends BaseToolHandler {
           include,
           approximate_bytes: 0,
           max_response_bytes: maxResponseBytes,
+          ...(shortPageReason ? { short_page_reason: shortPageReason } : {}),
         }
       });
 
@@ -948,12 +1044,13 @@ export class VConSearchHandler extends BaseToolHandler {
         );
       }
 
-      return this.createOkListResponse(items, page, {
+      return this.createOkListResponse(items, page as any, {
         meta: {
           mode,
           include,
           approximate_bytes: approximateBytes,
           max_response_bytes: maxResponseBytes,
+          ...(shortPageReason ? { short_page_reason: shortPageReason } : {}),
         }
       });
     } catch (error) {
@@ -974,7 +1071,29 @@ export class VConSearchHandler extends BaseToolHandler {
 export class VConTaxonomyHandler extends BaseToolHandler {
   readonly toolName = 'vcon_taxonomy';
 
-  protected async execute(_args: any, _context: ToolHandlerContext): Promise<ToolResponse> {
+  protected async execute(_args: any, context: ToolHandlerContext): Promise<ToolResponse> {
+    let coverage: Record<string, unknown> = { note: 'coverage unavailable' };
+    try {
+      const snap = await context.queries.getTaxonomyCoverageSnapshot();
+      if (snap.vcons_total != null) {
+        coverage = {
+          vcons_total: snap.vcons_total,
+          strolid_dealer_attachment: {
+            availability: 'preferred',
+            coverage_pct: snap.with_strolid_dealer_attachment_pct,
+            note: 'Percentage uses strolid_dealer attachment rows over total vCons (approximate if duplicates exist).',
+          },
+          dealer_name_tag: {
+            availability: 'sparse',
+            coverage_pct: snap.with_dealer_name_tag_pct,
+            note: 'Share of vCons whose tag materialized view exposes a dealer_name key.',
+          },
+        };
+      }
+    } catch {
+      /* keep static guidance when counts fail */
+    }
+
     return this.createOkItemResponse({
       dataset: 'strolid',
       portal_values: [
@@ -1032,8 +1151,57 @@ export class VConTaxonomyHandler extends BaseToolHandler {
           goal: 'Build dealer-aware list views',
           recommendation: 'Use the dealer attachment, not dealer_name tag coverage.',
         },
+        {
+          goal: 'Top N dealers by portal tag rate',
+          recommendation:
+            'Call vcon_aggregate with group_by="dealer", the same tags filter as numerator, include_baseline true, and having.min_count for a sample floor.',
+        },
       ],
+      coverage,
     });
+  }
+}
+
+export class VConAggregateHandler extends BaseToolHandler {
+  readonly toolName = 'vcon_aggregate';
+
+  protected async execute(args: any, context: ToolHandlerContext): Promise<ToolResponse> {
+    const groupBy = (args?.group_by as string | undefined) || 'dealer';
+    if (groupBy !== 'dealer') {
+      return this.createErrorEnvelopeResponse({
+        code: 'INVALID_ARGUMENT',
+        message: 'group_by must be "dealer" for this release.',
+      });
+    }
+
+    const tags = (args?.tags as Record<string, string> | undefined) ?? {};
+    const limit = Math.min(Math.max(Number(args?.limit ?? 20), 1), 500);
+    const minBaseline = Math.max(
+      1,
+      Number((args?.having as { min_count?: number } | undefined)?.min_count ?? 1),
+    );
+    const startDate = normalizeDateString(args?.filters?.start_date as string | undefined);
+    const endDate = normalizeDateString(args?.filters?.end_date as string | undefined);
+
+    try {
+      const rows = await context.queries.aggregateVconsByDealerStats({
+        tagFilter: tags,
+        startDate,
+        endDate,
+        minBaseline,
+        limit,
+      });
+      return this.createOkItemResponse({
+        group_by: 'dealer',
+        rows,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return this.createErrorEnvelopeResponse({
+        code: 'AGGREGATE_FAILED',
+        message,
+      });
+    }
   }
 }
 

--- a/src/tools/handlers/vcon-contract.ts
+++ b/src/tools/handlers/vcon-contract.ts
@@ -1,6 +1,7 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { BaseToolHandler, ToolHandlerContext, ToolResponse } from './base.js';
 import { VCon, Attachment, Analysis } from '../../types/vcon.js';
+import { VCON_SHAPE_GRAPH_JSON_SCHEMA } from '../../types/vcon-shape-graph.js';
 import { generateEmbedding } from '../../utils/embeddings.js';
 import { normalizeDateString } from './validation.js';
 
@@ -324,6 +325,7 @@ const SHAPE_DESCRIPTORS: Record<string, ShapeDescriptor> = {
           type: 'object',
           properties: {
             tools: { type: 'array' },
+            shape_graph: { type: 'object' },
             response_budgeting: { type: 'object' },
             fetch: { type: 'object' },
             search: { type: 'object' },
@@ -335,7 +337,14 @@ const SHAPE_DESCRIPTORS: Record<string, ShapeDescriptor> = {
     example: {
       ok: true,
       item: {
-        tools: ['vcon_fetch', 'vcon_search', 'vcon_taxonomy', 'vcon_aggregate', 'describe_response_shape'],
+        tools: ['vcon_fetch', 'vcon_capabilities', 'vcon_graph_shape', 'vcon_search', 'vcon_taxonomy', 'vcon_aggregate', 'describe_response_shape'],
+        shape_graph: {
+          resource_uri: 'vcon://v1/graph/shape',
+          tool: 'vcon_graph_shape',
+          json_schema_id: 'https://vcon.dev/mcp/shape-graph/1-0-0',
+          description:
+            'Corpus-level shape graph (analysis types, attachment purposes, legacy types, tag keys). Prefer the MCP resource when available.',
+        },
         response_budgeting: {
           default_max_response_bytes: 250000,
           minimum_max_response_bytes: 1024,
@@ -355,6 +364,47 @@ const SHAPE_DESCRIPTORS: Record<string, ShapeDescriptor> = {
         }
       }
     },
+  },
+  vcon_graph_shape: {
+    tool_name: 'vcon_graph_shape',
+    summary: 'OSS shape graph JSON: nodes for corpus structure and optional co-occurrence edges.',
+    response_schema: {
+      type: 'object',
+      required: ['ok', 'item'],
+      properties: {
+        ok: { type: 'boolean', const: true },
+        item: VCON_SHAPE_GRAPH_JSON_SCHEMA as unknown as Record<string, unknown>,
+      },
+    },
+    example: {
+      ok: true,
+      item: {
+        schema_version: '1.0.0',
+        generated_at: '2026-05-11T14:00:00Z',
+        corpus: {
+          vcons_with_tags_mv: 1200,
+          notes: ['Co-occurrence edges capped for bounded responses.'],
+        },
+        nodes: [
+          { id: 'analysis_type:summary', kind: 'analysis_type', label: 'summary', vcon_count: 800 },
+          { id: 'attachment_purpose:dealer_info', kind: 'attachment_purpose', label: 'dealer_info', vcon_count: 400 },
+          { id: 'tag_key:portal', kind: 'tag_key', label: 'portal', vcon_count: 900 },
+        ],
+        edges: [
+          {
+            id: 'analysis_type_with_attachment_purpose:summary|dealer_info',
+            kind: 'analysis_type_with_attachment_purpose',
+            source: 'analysis_type:summary',
+            target: 'attachment_purpose:dealer_info',
+            joint_vcon_count: 350,
+          },
+        ],
+      },
+    },
+    notes: [
+      'Same JSON as MCP resource vcon://v1/graph/shape.',
+      'See item.corpus.notes for backend-specific counting semantics.',
+    ],
   },
   vcon_search: {
     tool_name: 'vcon_search',
@@ -745,12 +795,44 @@ export class VConFetchHandler extends BaseToolHandler {
   }
 }
 
+export class VConGraphShapeHandler extends BaseToolHandler {
+  readonly toolName = 'vcon_graph_shape';
+
+  protected async execute(_args: unknown, context: ToolHandlerContext): Promise<ToolResponse> {
+    try {
+      const graph = await context.queries.getVconShapeGraph();
+      return this.createOkItemResponse(graph);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return this.createErrorEnvelopeResponse({
+        code: 'SHAPE_GRAPH_FAILED',
+        message,
+      });
+    }
+  }
+}
+
 export class VConCapabilitiesHandler extends BaseToolHandler {
   readonly toolName = 'vcon_capabilities';
 
   protected async execute(_args: any, _context: ToolHandlerContext): Promise<ToolResponse> {
     return this.createOkItemResponse({
-      tools: ['vcon_fetch', 'vcon_capabilities', 'vcon_search', 'vcon_taxonomy', 'vcon_aggregate', 'describe_response_shape'],
+      tools: [
+        'vcon_fetch',
+        'vcon_capabilities',
+        'vcon_graph_shape',
+        'vcon_search',
+        'vcon_taxonomy',
+        'vcon_aggregate',
+        'describe_response_shape',
+      ],
+      shape_graph: {
+        resource_uri: 'vcon://v1/graph/shape',
+        tool: 'vcon_graph_shape',
+        json_schema_id: VCON_SHAPE_GRAPH_JSON_SCHEMA.$id,
+        description:
+          'Default corpus-level graph from vCon structure only (analysis types, attachment purposes, legacy attachment types without purpose, tag keys, bounded co-occurrence). No business ontology. Read this resource or call vcon_graph_shape after vcon_capabilities and before broad search when teaching an agent what evidence exists.',
+      },
       response_budgeting: {
         default_max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
         minimum_max_response_bytes: MIN_MAX_RESPONSE_BYTES,

--- a/src/tools/vcon-contract.ts
+++ b/src/tools/vcon-contract.ts
@@ -115,14 +115,22 @@ export const vconSearchTool = {
       },
       filters: {
         type: 'object',
-        description: 'Structured metadata filters for subject, dates, and party fields.',
+        description: 'Structured metadata filters for subject, dates, party fields, and strolid dealer attachment.',
         properties: {
           subject: { type: 'string' },
           start_date: { type: 'string' },
           end_date: { type: 'string' },
           party_name: { type: 'string' },
           party_email: { type: 'string' },
-          party_tel: { type: 'string' }
+          party_tel: { type: 'string' },
+          dealer_id: {
+            type: 'string',
+            description: 'Match strolid_dealer attachment id (use string form, for example "1174").',
+          },
+          dealer_name: {
+            type: 'string',
+            description: 'Case-insensitive substring match against strolid_dealer attachment name.',
+          },
         }
       },
       include: {
@@ -168,6 +176,53 @@ export const vconSearchTool = {
   }
 };
 
+export const vconAggregateTool = {
+  name: 'vcon_aggregate',
+  category: 'read' as ToolCategory,
+  description:
+    'Server-side rollup for analyst questions such as top dealers by portal-tag rate. ' +
+    'Groups vCons that carry a strolid_dealer attachment by dealer id, returning filtered_count (rows matching tags) and baseline_count (all rows in the group) so clients can divide for a rate in one round trip. ' +
+    'Requires Postgres RPC aggregate_vcons_by_dealer_stats from the latest migration.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      group_by: {
+        type: 'string',
+        enum: ['dealer'],
+        description: 'Only "dealer" is supported in this release.',
+        default: 'dealer',
+      },
+      tags: {
+        type: 'object',
+        description: 'Tag filter for the numerator (same shape as vcon_search tags). Pass {} for baseline-only ranking.',
+        additionalProperties: { type: 'string' },
+      },
+      filters: {
+        type: 'object',
+        description: 'Optional created_at window on vcons.created_at.',
+        properties: {
+          start_date: { type: 'string' },
+          end_date: { type: 'string' },
+        },
+      },
+      having: {
+        type: 'object',
+        description: 'Optional HAVING-style floor on baseline_count per dealer.',
+        properties: {
+          min_count: { type: 'number', minimum: 1, default: 1 },
+        },
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of dealer rows to return. Default 20, max 500.',
+        minimum: 1,
+        maximum: 500,
+        default: 20,
+      },
+    },
+  },
+};
+
 export const describeResponseShapeTool = {
   name: 'describe_response_shape',
   category: 'read' as ToolCategory,
@@ -181,7 +236,7 @@ export const describeResponseShapeTool = {
       tool_name: {
         type: 'string',
         description:
-          'Tool name to describe. Supported values include vcon_fetch, vcon_capabilities, vcon_search, vcon_taxonomy, describe_response_shape, get_vcon, search_vcons, search_by_tags, search_vcons_content, search_vcons_semantic, and search_vcons_hybrid.'
+          'Tool name to describe. Supported values include vcon_fetch, vcon_capabilities, vcon_search, vcon_taxonomy, vcon_aggregate, describe_response_shape, get_vcon, search_vcons, search_by_tags, search_vcons_content, search_vcons_semantic, and search_vcons_hybrid.'
       },
       include_example: {
         type: 'boolean',
@@ -197,5 +252,6 @@ export const allContractTools = [
   vconCapabilitiesTool,
   vconTaxonomyTool,
   vconSearchTool,
+  vconAggregateTool,
   describeResponseShapeTool,
 ];

--- a/src/tools/vcon-contract.ts
+++ b/src/tools/vcon-contract.ts
@@ -78,6 +78,19 @@ export const vconCapabilitiesTool = {
   }
 };
 
+export const vconGraphShapeTool = {
+  name: 'vcon_graph_shape',
+  category: 'read' as ToolCategory,
+  description:
+    'Return the default OSS vCon shape graph for this corpus: nodes for analysis types, attachment purposes, legacy attachment types (when purpose is absent), and tag keys, plus optional co-occurrence edges between analysis types and attachment purposes. ' +
+    'Spec-generic structure only; no business ontology. Same payload as MCP resource vcon://v1/graph/shape. ' +
+    'Prefer the resource when the client supports resources; use this tool otherwise.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {},
+  },
+};
+
 export const vconSearchTool = {
   name: 'vcon_search',
   category: 'read' as ToolCategory,
@@ -236,7 +249,7 @@ export const describeResponseShapeTool = {
       tool_name: {
         type: 'string',
         description:
-          'Tool name to describe. Supported values include vcon_fetch, vcon_capabilities, vcon_search, vcon_taxonomy, vcon_aggregate, describe_response_shape, get_vcon, search_vcons, search_by_tags, search_vcons_content, search_vcons_semantic, and search_vcons_hybrid.'
+          'Tool name to describe. Supported values include vcon_fetch, vcon_capabilities, vcon_graph_shape, vcon_search, vcon_taxonomy, vcon_aggregate, describe_response_shape, get_vcon, search_vcons, search_by_tags, search_vcons_content, search_vcons_semantic, and search_vcons_hybrid.'
       },
       include_example: {
         type: 'boolean',
@@ -250,6 +263,7 @@ export const describeResponseShapeTool = {
 export const allContractTools = [
   vconFetchTool,
   vconCapabilitiesTool,
+  vconGraphShapeTool,
   vconTaxonomyTool,
   vconSearchTool,
   vconAggregateTool,

--- a/src/tools/vcon-crud.ts
+++ b/src/tools/vcon-crud.ts
@@ -83,7 +83,8 @@ export const PartySchema = z.object({
  * ✅ Includes dialog reference
  */
 export const AttachmentSchema = z.object({
-  type: z.string().optional(),
+  purpose: z.string().optional().describe('Canonical spec field for attachment classification'),
+  type: z.string().optional().describe('Legacy compatibility field; prefer purpose for new data'),
   start: z.string().optional(),
   party: z.number().optional(),
   dialog: z.number().optional().describe('Dialog index this attachment relates to'),  // ✅ Added
@@ -564,7 +565,14 @@ export const addAttachmentTool = {
       attachment: {
         type: 'object',
         properties: {
-          type: { type: 'string' },
+          purpose: {
+            type: 'string',
+            description: 'Canonical spec field for attachment classification'
+          },
+          type: {
+            type: 'string',
+            description: 'Legacy compatibility field; prefer purpose for new data'
+          },
           party: {
             type: 'number',
             description: 'Party index this attachment relates to'

--- a/src/types/vcon-shape-graph.ts
+++ b/src/types/vcon-shape-graph.ts
@@ -1,0 +1,98 @@
+/**
+ * OSS vCon "shape graph": corpus-level view of analysis types, attachment purposes,
+ * legacy attachment types (no purpose), and tag keys. No business ontology.
+ *
+ * JSON payload uses explicit kinds so clients can evolve without breaking ids.
+ */
+
+export const VCON_SHAPE_GRAPH_SCHEMA_VERSION = '1.0.0' as const;
+
+/** Node kinds emitted by the default shape graph builder */
+export type VconShapeGraphNodeKind =
+  | 'analysis_type'
+  | 'attachment_purpose'
+  | 'attachment_type_legacy'
+  | 'tag_key';
+
+export interface VconShapeGraphNode {
+  /** Stable id within this graph, e.g. "analysis_type:summary" */
+  id: string;
+  kind: VconShapeGraphNodeKind;
+  /** Human-readable label (same as value for type/purpose/key) */
+  label: string;
+  /** Distinct vCons that reference this node (when available) */
+  vcon_count?: number;
+}
+
+export type VconShapeGraphEdgeKind = 'analysis_type_with_attachment_purpose';
+
+export interface VconShapeGraphEdge {
+  id: string;
+  kind: VconShapeGraphEdgeKind;
+  source: string;
+  target: string;
+  /** Distinct vCons where both endpoints co-occur */
+  joint_vcon_count: number;
+}
+
+export interface VconShapeGraphPayload {
+  schema_version: typeof VCON_SHAPE_GRAPH_SCHEMA_VERSION;
+  generated_at: string;
+  corpus: {
+    /** vCons counted in tag-key path (distinct vcon_id in vcon_tags_mv when available) */
+    vcons_with_tags_mv?: number;
+    notes: string[];
+  };
+  nodes: VconShapeGraphNode[];
+  edges: VconShapeGraphEdge[];
+}
+
+/** JSON Schema subset for LLM-facing documentation (not exhaustive of all JSON Schema keywords). */
+export const VCON_SHAPE_GRAPH_JSON_SCHEMA = {
+  $id: 'https://vcon.dev/mcp/shape-graph/1-0-0',
+  title: 'vConShapeGraphPayload',
+  type: 'object',
+  required: ['schema_version', 'generated_at', 'corpus', 'nodes', 'edges'],
+  properties: {
+    schema_version: { type: 'string', const: VCON_SHAPE_GRAPH_SCHEMA_VERSION },
+    generated_at: { type: 'string', format: 'date-time' },
+    corpus: {
+      type: 'object',
+      required: ['notes'],
+      properties: {
+        vcons_with_tags_mv: { type: 'integer', minimum: 0 },
+        notes: { type: 'array', items: { type: 'string' } },
+      },
+    },
+    nodes: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'kind', 'label'],
+        properties: {
+          id: { type: 'string' },
+          kind: {
+            type: 'string',
+            enum: ['analysis_type', 'attachment_purpose', 'attachment_type_legacy', 'tag_key'],
+          },
+          label: { type: 'string' },
+          vcon_count: { type: 'integer', minimum: 0 },
+        },
+      },
+    },
+    edges: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'kind', 'source', 'target', 'joint_vcon_count'],
+        properties: {
+          id: { type: 'string' },
+          kind: { type: 'string', const: 'analysis_type_with_attachment_purpose' },
+          source: { type: 'string' },
+          target: { type: 'string' },
+          joint_vcon_count: { type: 'integer', minimum: 0 },
+        },
+      },
+    },
+  },
+} as const;

--- a/src/types/vcon.ts
+++ b/src/types/vcon.ts
@@ -144,7 +144,7 @@ export interface Dialog {
  * Attachment Object - Section 4.4
  */
 export interface Attachment {
-  purpose?: string;         // Section 4.4.1
+  purpose?: string;         // Section 4.4.1 - canonical spec field for attachment classification
   start?: string;           // Section 4.4.2 - ISO 8601 datetime
   party?: number;           // Section 4.4.3
   dialog?: number;          // Section 4.4.4
@@ -154,7 +154,7 @@ export interface Attachment {
   encoding?: Encoding;
   url?: string;
   content_hash?: string | string[];
-  // Non-spec fields used by Strolid for custom attachment types (stored in metadata)
+  // Legacy/non-spec compatibility field. Prefer purpose for new writes and reads.
   type?: string;
 }
 

--- a/src/utils/read-surfaces.ts
+++ b/src/utils/read-surfaces.ts
@@ -1,0 +1,84 @@
+import type { DistinctValuesResult } from '../db/interfaces.js';
+import type { Analysis, Attachment, VCon } from '../types/vcon.js';
+
+export interface DiscoveryValue {
+  value: string;
+  count?: number;
+}
+
+export function toDiscoveryValues(result: DistinctValuesResult): DiscoveryValue[] {
+  return result.values.map((value) => ({
+    value,
+    ...(result.countsPerValue && result.countsPerValue[value] !== undefined
+      ? { count: result.countsPerValue[value] }
+      : {}),
+  }));
+}
+
+export function getVConMetadata(vcon: VCon): Record<string, unknown> {
+  const metadata = { ...(vcon as unknown as Record<string, unknown>) };
+  delete (metadata as any).parties;
+  delete (metadata as any).dialog;
+  delete (metadata as any).analysis;
+  delete (metadata as any).attachments;
+  return metadata;
+}
+
+export function filterAttachments(
+  vcon: VCon,
+  filters: {
+    type?: string;
+    purpose?: string;
+  } = {},
+): Attachment[] {
+  return (vcon.attachments || []).filter((attachment) => {
+    if (filters.type && attachment.type !== filters.type) {
+      return false;
+    }
+    if (filters.purpose && attachment.purpose !== filters.purpose) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function filterAnalysis(
+  vcon: VCon,
+  filters: {
+    type?: string;
+  } = {},
+): Analysis[] {
+  return (vcon.analysis || []).filter((analysis) => {
+    if (filters.type && analysis.type !== filters.type) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function extractTags(vcon: VCon): Record<string, string> {
+  const tagsAttachment = filterAttachments(vcon, { type: 'tags' })[0];
+  if (!tagsAttachment || tagsAttachment.body === undefined || tagsAttachment.body === null) {
+    return {};
+  }
+
+  try {
+    const parsed =
+      typeof tagsAttachment.body === 'string'
+        ? JSON.parse(tagsAttachment.body)
+        : tagsAttachment.body;
+    const tagsArray = Array.isArray(parsed) ? parsed : [];
+    const tagsObject: Record<string, string> = {};
+
+    for (const tag of tagsArray) {
+      if (typeof tag !== 'string') continue;
+      const colonIndex = tag.indexOf(':');
+      if (colonIndex <= 0) continue;
+      tagsObject[tag.slice(0, colonIndex)] = tag.slice(colonIndex + 1);
+    }
+
+    return tagsObject;
+  } catch {
+    return {};
+  }
+}

--- a/src/utils/responses.ts
+++ b/src/utils/responses.ts
@@ -9,6 +9,8 @@ import { ToolResponse } from '../tools/handlers/base.js';
 export interface EnvelopePage {
   count: number;
   total?: number;
+  /** When set, clients must not assume they can page beyond this many rows even if total is higher. */
+  iterable_total?: number;
   next_cursor?: string | null;
 }
 

--- a/supabase/migrations/20260512180000_vcon_dealer_filter_and_aggregate.sql
+++ b/supabase/migrations/20260512180000_vcon_dealer_filter_and_aggregate.sql
@@ -1,0 +1,204 @@
+-- Dealer-scoped UUID lookup for search filters and aggregate rollups by dealer.
+
+CREATE OR REPLACE FUNCTION vcon_uuids_for_dealer_filter(
+  p_dealer_id text DEFAULT NULL,
+  p_name_ilike text DEFAULT NULL
+) RETURNS TABLE (vcon_uuid uuid) AS $$
+DECLARE
+  current_tenant text;
+BEGIN
+  current_tenant := get_current_tenant_id();
+
+  IF p_dealer_id IS NULL AND (p_name_ilike IS NULL OR length(trim(p_name_ilike)) = 0) THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT v.uuid
+  FROM vcons v
+  INNER JOIN attachments d ON d.vcon_id = v.id AND d.type = 'strolid_dealer'
+  WHERE (current_tenant IS NULL OR v.tenant_id IS NULL OR v.tenant_id = current_tenant)
+    AND (
+      p_dealer_id IS NULL
+      OR (d.body::jsonb->>'id') = p_dealer_id
+    )
+    AND (
+      p_name_ilike IS NULL OR length(trim(p_name_ilike)) = 0
+      OR (d.body::jsonb->>'name') ILIKE ('%' || p_name_ilike || '%')
+    );
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+GRANT EXECUTE ON FUNCTION vcon_uuids_for_dealer_filter(text, text) TO anon, authenticated, service_role;
+
+-- Grouped counts per dealer: optional tag numerator + baseline denominator.
+CREATE OR REPLACE FUNCTION aggregate_vcons_by_dealer_stats(
+  tag_filter          jsonb DEFAULT '{}'::jsonb,
+  vcon_created_after  timestamptz DEFAULT NULL,
+  vcon_created_before timestamptz DEFAULT NULL,
+  min_baseline        int DEFAULT 1,
+  max_results         int DEFAULT 20
+) RETURNS TABLE (
+  dealer_id text,
+  dealer_name text,
+  team_id int,
+  team_name text,
+  filtered_count bigint,
+  baseline_count bigint
+) AS $$
+DECLARE
+  current_tenant text;
+BEGIN
+  current_tenant := get_current_tenant_id();
+
+  RETURN QUERY
+  WITH base AS (
+    SELECT
+      v.id AS vid,
+      NULLIF(trim(both FROM (d.body::jsonb->>'id')), '') AS did,
+      COALESCE(NULLIF(trim(both FROM (d.body::jsonb->>'name')), ''), '') AS dname,
+      CASE
+        WHEN jsonb_typeof(d.body::jsonb->'team') = 'object'
+          AND d.body::jsonb->'team' IS NOT NULL
+          AND d.body::jsonb->'team' <> '{}'::jsonb
+        THEN NULLIF((d.body::jsonb->'team'->>'id'), '')::int
+        ELSE NULL::int
+      END AS tid,
+      CASE
+        WHEN jsonb_typeof(d.body::jsonb->'team') = 'object'
+          AND d.body::jsonb->'team' IS NOT NULL
+          AND d.body::jsonb->'team' <> '{}'::jsonb
+        THEN NULLIF(trim(both FROM (d.body::jsonb->'team'->>'name')), '')
+        ELSE NULL::text
+      END AS tname,
+      ta.tags AS tagdoc
+    FROM vcons v
+    INNER JOIN attachments d ON d.vcon_id = v.id AND d.type = 'strolid_dealer'
+    LEFT JOIN vcon_tags_mv ta ON ta.vcon_id = v.id
+    WHERE (current_tenant IS NULL OR v.tenant_id IS NULL OR v.tenant_id = current_tenant)
+      AND (vcon_created_after IS NULL OR v.created_at >= vcon_created_after)
+      AND (vcon_created_before IS NULL OR v.created_at <= vcon_created_before)
+      AND d.body::jsonb ? 'id'
+  ),
+  rolled AS (
+    SELECT
+      b.did AS dealer_id,
+      max(b.dname) AS dealer_name,
+      max(b.tid) AS team_id,
+      max(b.tname) AS team_name,
+      COUNT(*)::bigint AS baseline_count,
+      COUNT(*) FILTER (
+        WHERE tag_filter = '{}'::jsonb
+          OR (b.tagdoc IS NOT NULL AND b.tagdoc @> tag_filter)
+      )::bigint AS filtered_count
+    FROM base b
+    WHERE b.did IS NOT NULL
+    GROUP BY b.did
+  )
+  SELECT
+    r.dealer_id,
+    r.dealer_name,
+    r.team_id,
+    r.team_name,
+    r.filtered_count,
+    r.baseline_count
+  FROM rolled r
+  WHERE r.baseline_count >= min_baseline
+  ORDER BY
+    (r.filtered_count::double precision / NULLIF(r.baseline_count, 0)::double precision) DESC NULLS LAST,
+    r.filtered_count DESC,
+    r.baseline_count DESC
+  LIMIT GREATEST(1, LEAST(max_results, 500));
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+GRANT EXECUTE ON FUNCTION aggregate_vcons_by_dealer_stats(jsonb, timestamptz, timestamptz, int, int)
+  TO anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION count_vcons_for_dealer_filter(
+  p_dealer_id text DEFAULT NULL,
+  p_name_ilike text DEFAULT NULL,
+  p_subject_contains text DEFAULT NULL,
+  vcon_created_after timestamptz DEFAULT NULL,
+  vcon_created_before timestamptz DEFAULT NULL
+) RETURNS bigint AS $$
+DECLARE
+  current_tenant text;
+  n bigint;
+BEGIN
+  current_tenant := get_current_tenant_id();
+
+  IF p_dealer_id IS NULL AND (p_name_ilike IS NULL OR length(trim(p_name_ilike)) = 0) THEN
+    RETURN 0;
+  END IF;
+
+  SELECT COUNT(DISTINCT v.id)::bigint INTO n
+  FROM vcons v
+  INNER JOIN attachments d ON d.vcon_id = v.id AND d.type = 'strolid_dealer'
+  WHERE (current_tenant IS NULL OR v.tenant_id IS NULL OR v.tenant_id = current_tenant)
+    AND (vcon_created_after IS NULL OR v.created_at >= vcon_created_after)
+    AND (vcon_created_before IS NULL OR v.created_at <= vcon_created_before)
+    AND (
+      p_dealer_id IS NULL
+      OR (d.body::jsonb->>'id') = p_dealer_id
+    )
+    AND (
+      p_name_ilike IS NULL OR length(trim(p_name_ilike)) = 0
+      OR (d.body::jsonb->>'name') ILIKE ('%' || p_name_ilike || '%')
+    )
+    AND (
+      p_subject_contains IS NULL OR length(trim(p_subject_contains)) = 0
+      OR v.subject ILIKE ('%' || p_subject_contains || '%')
+    );
+
+  RETURN COALESCE(n, 0);
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+GRANT EXECUTE ON FUNCTION count_vcons_for_dealer_filter(text, text, text, timestamptz, timestamptz)
+  TO anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION count_vcons_tags_and_dealer(
+  tag_filter          jsonb DEFAULT '{}'::jsonb,
+  p_dealer_id         text DEFAULT NULL,
+  p_name_ilike        text DEFAULT NULL,
+  vcon_created_after  timestamptz DEFAULT NULL,
+  vcon_created_before timestamptz DEFAULT NULL,
+  p_subject_contains  text DEFAULT NULL
+) RETURNS bigint AS $$
+DECLARE
+  current_tenant text;
+  n bigint;
+BEGIN
+  current_tenant := get_current_tenant_id();
+
+  IF tag_filter = '{}'::jsonb THEN
+    RETURN 0;
+  END IF;
+
+  SELECT COUNT(DISTINCT v.id)::bigint INTO n
+  FROM vcons v
+  INNER JOIN vcon_tags_mv ta ON ta.vcon_id = v.id AND ta.tags IS NOT NULL AND ta.tags @> tag_filter
+  INNER JOIN attachments d ON d.vcon_id = v.id AND d.type = 'strolid_dealer'
+  WHERE (current_tenant IS NULL OR v.tenant_id IS NULL OR v.tenant_id = current_tenant)
+    AND (vcon_created_after IS NULL OR v.created_at >= vcon_created_after)
+    AND (vcon_created_before IS NULL OR v.created_at <= vcon_created_before)
+    AND (
+      p_dealer_id IS NULL
+      OR (d.body::jsonb->>'id') = p_dealer_id
+    )
+    AND (
+      p_name_ilike IS NULL OR length(trim(p_name_ilike)) = 0
+      OR (d.body::jsonb->>'name') ILIKE ('%' || p_name_ilike || '%')
+    )
+    AND (
+      p_subject_contains IS NULL OR length(trim(p_subject_contains)) = 0
+      OR v.subject ILIKE ('%' || p_subject_contains || '%')
+    );
+
+  RETURN COALESCE(n, 0);
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+GRANT EXECUTE ON FUNCTION count_vcons_tags_and_dealer(jsonb, text, text, timestamptz, timestamptz, text)
+  TO anon, authenticated, service_role;

--- a/tests/api/helpers.ts
+++ b/tests/api/helpers.ts
@@ -56,6 +56,16 @@ export function createMockQueries() {
     removeAllTags: vi.fn(),
     searchByTags: vi.fn().mockResolvedValue([]),
     getUniqueTags: vi.fn().mockResolvedValue({ keys: [], tagsByKey: {}, totalVCons: 0 }),
+    getUniqueAttachmentTypes: vi.fn().mockResolvedValue({ values: [], totalVCons: 0 }),
+    getUniqueAttachmentPurposes: vi.fn().mockResolvedValue({ values: [], totalVCons: 0 }),
+    getUniqueAnalysisTypes: vi.fn().mockResolvedValue({ values: [], totalVCons: 0 }),
+    getVconShapeGraph: vi.fn().mockResolvedValue({
+      schema_version: '1.0.0',
+      generated_at: new Date().toISOString(),
+      corpus: { notes: [] },
+      nodes: [],
+      edges: [],
+    }),
   };
 }
 

--- a/tests/api/routes/discovery.test.ts
+++ b/tests/api/routes/discovery.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createTestApp, type TestAppContext } from '../helpers.js';
+
+describe('Discovery Routes', () => {
+  let ctx: TestAppContext;
+  const BASE = '/api/v1';
+
+  beforeEach(() => {
+    ctx = createTestApp();
+  });
+
+  describe('GET /discovery/attachments/types', () => {
+    it('should return discovered attachment types with counts by default', async () => {
+      ctx.mocks.queries.getUniqueAttachmentTypes.mockResolvedValueOnce({
+        values: ['document', 'tags'],
+        countsPerValue: { document: 4, tags: 2 },
+        totalVCons: 5,
+      });
+
+      const res = await request(ctx.app.callback())
+        .get(`${BASE}/discovery/attachments/types`)
+        .expect(200);
+
+      expect(res.body.count).toBe(2);
+      expect(res.body.total_vcons).toBe(5);
+      expect(res.body.attachment_types).toEqual([
+        { value: 'document', count: 4 },
+        { value: 'tags', count: 2 },
+      ]);
+      expect(ctx.mocks.queries.getUniqueAttachmentTypes).toHaveBeenCalledWith({
+        includeCounts: true,
+        minCount: 1,
+      });
+    });
+  });
+
+  describe('GET /discovery/attachments/purposes', () => {
+    it('should honor include_counts and min_count query params', async () => {
+      ctx.mocks.queries.getUniqueAttachmentPurposes.mockResolvedValueOnce({
+        values: ['dealer_info'],
+        totalVCons: 2,
+      });
+
+      const res = await request(ctx.app.callback())
+        .get(`${BASE}/discovery/attachments/purposes?include_counts=false&min_count=2`)
+        .expect(200);
+
+      expect(res.body.attachment_purposes).toEqual([
+        { value: 'dealer_info' },
+      ]);
+      expect(ctx.mocks.queries.getUniqueAttachmentPurposes).toHaveBeenCalledWith({
+        includeCounts: false,
+        minCount: 2,
+      });
+    });
+  });
+
+  describe('GET /discovery/analysis/types', () => {
+    it('should reject invalid min_count values', async () => {
+      const res = await request(ctx.app.callback())
+        .get(`${BASE}/discovery/analysis/types?min_count=0`)
+        .expect(400);
+
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toContain('min_count');
+    });
+  });
+});

--- a/tests/api/routes/vcons.test.ts
+++ b/tests/api/routes/vcons.test.ts
@@ -198,6 +198,92 @@ describe('vCon CRUD Routes', () => {
     });
   });
 
+  describe('GET /vcons/:uuid/analysis', () => {
+    it('should return all analysis when no filter is provided', async () => {
+      const uuid = randomUUID();
+      const vcon = sampleVCon({
+        uuid,
+        analysis: [
+          { type: 'summary', vendor: 'test', body: 'summary' } as any,
+          { type: 'transcript', vendor: 'test', body: 'transcript' } as any,
+        ],
+      });
+      ctx.mocks.vconService.get.mockResolvedValueOnce(vcon);
+
+      const res = await request(ctx.app.callback())
+        .get(`${BASE}/vcons/${uuid}/analysis`)
+        .expect(200);
+
+      expect(res.body.count).toBe(2);
+      expect(res.body.analysis).toHaveLength(2);
+    });
+
+    it('should filter analysis by type', async () => {
+      const uuid = randomUUID();
+      const vcon = sampleVCon({
+        uuid,
+        analysis: [
+          { type: 'summary', vendor: 'test', body: 'summary' } as any,
+          { type: 'transcript', vendor: 'test', body: 'transcript' } as any,
+        ],
+      });
+      ctx.mocks.vconService.get.mockResolvedValueOnce(vcon);
+
+      const res = await request(ctx.app.callback())
+        .get(`${BASE}/vcons/${uuid}/analysis?type=summary`)
+        .expect(200);
+
+      expect(res.body.count).toBe(1);
+      expect(res.body.type).toBe('summary');
+      expect(res.body.analysis).toHaveLength(1);
+      expect(res.body.analysis[0].type).toBe('summary');
+    });
+  });
+
+  describe('GET /vcons/:uuid/attachments', () => {
+    it('should return all attachments when no filter is provided', async () => {
+      const uuid = randomUUID();
+      const vcon = sampleVCon({
+        uuid,
+        attachments: [
+          { type: 'document', purpose: 'dealer_info', body: 'dealer', encoding: 'none' } as any,
+          { type: 'tags', purpose: 'classification', body: '["priority:high"]', encoding: 'json' } as any,
+        ],
+      });
+      ctx.mocks.vconService.get.mockResolvedValueOnce(vcon);
+
+      const res = await request(ctx.app.callback())
+        .get(`${BASE}/vcons/${uuid}/attachments`)
+        .expect(200);
+
+      expect(res.body.count).toBe(2);
+      expect(res.body.attachments).toHaveLength(2);
+    });
+
+    it('should filter attachments by type and purpose', async () => {
+      const uuid = randomUUID();
+      const vcon = sampleVCon({
+        uuid,
+        attachments: [
+          { type: 'document', purpose: 'dealer_info', body: 'dealer', encoding: 'none' } as any,
+          { type: 'document', purpose: 'invoice', body: 'invoice', encoding: 'none' } as any,
+          { type: 'tags', purpose: 'classification', body: '["priority:high"]', encoding: 'json' } as any,
+        ],
+      });
+      ctx.mocks.vconService.get.mockResolvedValueOnce(vcon);
+
+      const res = await request(ctx.app.callback())
+        .get(`${BASE}/vcons/${uuid}/attachments?type=document&purpose=dealer_info`)
+        .expect(200);
+
+      expect(res.body.count).toBe(1);
+      expect(res.body.type).toBe('document');
+      expect(res.body.purpose).toBe('dealer_info');
+      expect(res.body.attachments).toHaveLength(1);
+      expect(res.body.attachments[0].purpose).toBe('dealer_info');
+    });
+  });
+
   // ── PATCH /vcons/:uuid ──────────────────────────────────────────────────
 
   describe('PATCH /vcons/:uuid', () => {

--- a/tests/db-queries.test.ts
+++ b/tests/db-queries.test.ts
@@ -32,6 +32,7 @@ describe('VConQueries', () => {
         or: vi.fn(),
         range: vi.fn(),
         in: vi.fn(),
+        rpc: vi.fn(),
       };
 
       // Make all methods return the mock itself for chaining
@@ -719,6 +720,69 @@ describe('VConQueries', () => {
 
       // Should use index 0 when no existing attachments
       expect(mockSupabase.insert).toHaveBeenCalled();
+    });
+  });
+
+  describe('distinct category discovery', () => {
+    it('should return attachment types from the SQL fast path', async () => {
+      mockSupabase.rpc
+        .mockResolvedValueOnce({
+          data: [
+            { value: 'document', cnt: 3 },
+            { value: 'tags', cnt: 1 },
+          ],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [{ total: 2 }],
+          error: null,
+        });
+
+      const result = await queries.getUniqueAttachmentTypes({ includeCounts: true });
+
+      expect(result).toEqual({
+        values: ['document', 'tags'],
+        countsPerValue: {
+          document: 3,
+          tags: 1,
+        },
+        totalVCons: 2,
+      });
+    });
+
+    it('should fall back to batch scanning for attachment purposes when SQL is unavailable', async () => {
+      mockSupabase.rpc
+        .mockResolvedValueOnce({
+          data: null,
+          error: { code: 'PGRST202', message: 'Could not find the function public.exec_sql' },
+        })
+        .mockResolvedValueOnce({
+          data: null,
+          error: { code: 'PGRST202', message: 'Could not find the function public.exec_sql' },
+        });
+      mockSupabase.select.mockResolvedValueOnce({
+        count: 4,
+        error: null,
+      });
+      mockSupabase.range.mockResolvedValueOnce({
+        data: [
+          { vcon_id: 'v1', purpose: 'dealer_info' },
+          { vcon_id: 'v2', purpose: ' dealer_info ' },
+          { vcon_id: 'v2', purpose: '' },
+          { vcon_id: 'v3', purpose: null },
+        ],
+        error: null,
+      });
+
+      const result = await queries.getUniqueAttachmentPurposes({ includeCounts: true });
+
+      expect(result).toEqual({
+        values: ['dealer_info'],
+        countsPerValue: {
+          dealer_info: 2,
+        },
+        totalVCons: 2,
+      });
     });
   });
 });

--- a/tests/e2e/mcp-client.test.ts
+++ b/tests/e2e/mcp-client.test.ts
@@ -571,7 +571,8 @@ describe.skipIf(!runE2E)('MCP Server E2E Tests', () => {
     });
   });
 
-  describe('Text Search (search_vcons_content)', () => {
+  // Full-text RPC can exceed 30s on large local corpora (see QA plan E2E notes).
+  describe('Text Search (search_vcons_content)', { timeout: 120_000 }, () => {
     it('should execute text search and return results', async () => {
       if (skipIfNoSchema()) return;
 

--- a/tests/handlers/registry-init.test.ts
+++ b/tests/handlers/registry-init.test.ts
@@ -50,6 +50,7 @@ describe('Handler Registry Initialization', () => {
 
     expect(registry.has('vcon_fetch')).toBe(true);
     expect(registry.has('vcon_capabilities')).toBe(true);
+    expect(registry.has('vcon_graph_shape')).toBe(true);
     expect(registry.has('vcon_search')).toBe(true);
     expect(registry.has('vcon_taxonomy')).toBe(true);
     expect(registry.has('describe_response_shape')).toBe(true);
@@ -99,13 +100,13 @@ describe('Handler Registry Initialization', () => {
     // Schema: 2
     // CRUD: 8
     // Search: 4
-    // Contract: 5
+    // Contract: 7
     // Tags: 5
     // Database: 3
     // Analytics: 6
     // Size: 2
-    // Total: 35
-    expect(toolNames.length).toBe(35);
+    // Total: 37
+    expect(toolNames.length).toBe(37);
   });
 
   it('should allow retrieving handlers by name', () => {

--- a/tests/handlers/schema.test.ts
+++ b/tests/handlers/schema.test.ts
@@ -46,8 +46,9 @@ describe('Schema Handlers', () => {
       const result = await handler.handle({}, mockContext);
 
       const response = JSON.parse(result.content[0].text);
-      expect(response.success).toBe(true);
-      expect(response.note).toContain('JSON Schema export');
+      expect(response.definitions?.VCon).toBeDefined();
+      expect(response.definitions.VCon.type).toBe('object');
+      expect(response.$ref).toMatch(/VCon/);
     });
 
     it('should return JSON schema format when explicitly requested', async () => {
@@ -57,7 +58,7 @@ describe('Schema Handlers', () => {
       }, mockContext);
 
       const response = JSON.parse(result.content[0].text);
-      expect(response.success).toBe(true);
+      expect(response.definitions?.VCon?.properties?.parties).toBeDefined();
     });
 
     it('should return TypeScript format when requested', async () => {
@@ -66,7 +67,8 @@ describe('Schema Handlers', () => {
         format: 'typescript',
       }, mockContext);
 
-      expect(result.content[0].text).toContain('src/types/vcon.ts');
+      expect(result.content[0].text).toContain('IETF vCon Core Types');
+      expect(result.content[0].text).toContain('export interface VCon');
     });
 
     it('should throw error for unsupported format', async () => {
@@ -88,7 +90,7 @@ describe('Schema Handlers', () => {
       }, mockContext);
 
       const response = JSON.parse(result.content[0].text);
-      expect(response.vcon).toBe('0.3.0');
+      expect(response.vcon).toBe('0.4.0');
       expect(response.parties).toBeDefined();
     });
 
@@ -99,7 +101,7 @@ describe('Schema Handlers', () => {
       }, mockContext);
 
       const response = JSON.parse(result.content[0].text);
-      expect(response.subject).toBe('Phone Call');
+      expect(response.subject).toBe('Customer support call');
       expect(response.dialog).toBeDefined();
     });
 
@@ -110,7 +112,7 @@ describe('Schema Handlers', () => {
       }, mockContext);
 
       const response = JSON.parse(result.content[0].text);
-      expect(response.subject).toBe('Chat');
+      expect(response.subject).toBe('Sales chat');
     });
 
     it('should return email example', async () => {
@@ -120,7 +122,7 @@ describe('Schema Handlers', () => {
       }, mockContext);
 
       const response = JSON.parse(result.content[0].text);
-      expect(response.subject).toBe('Email Thread');
+      expect(response.subject).toBe('Contract review');
       expect(response.attachments).toBeDefined();
     });
 
@@ -131,7 +133,7 @@ describe('Schema Handlers', () => {
       }, mockContext);
 
       const response = JSON.parse(result.content[0].text);
-      expect(response.subject).toBe('Video Meeting');
+      expect(response.subject).toBe('Quarterly review');
     });
 
     it('should return full_featured example', async () => {

--- a/tests/handlers/tool-categories.test.ts
+++ b/tests/handlers/tool-categories.test.ts
@@ -116,9 +116,9 @@ describe('Tool Categories Integration', () => {
     it('should have expected number of read tools', () => {
       const readTools = allToolsWithCategories.filter((t) => t.category === 'read');
       // get_vcon, search_vcons, search_vcons_content, search_vcons_semantic, search_vcons_hybrid
-      // vcon_fetch, vcon_capabilities, vcon_search, vcon_taxonomy, describe_response_shape
+      // vcon_fetch, vcon_capabilities, vcon_graph_shape, vcon_taxonomy, vcon_search, vcon_aggregate, describe_response_shape
       // get_tags, search_by_tags, get_unique_tags
-      expect(readTools.length).toBe(13);
+      expect(readTools.length).toBe(15);
     });
 
     it('should have expected number of write tools', () => {
@@ -147,24 +147,24 @@ describe('Tool Categories Integration', () => {
       expect(infraTools.length).toBe(5);
     });
 
-    it('should have 35 total tools', () => {
-      expect(allToolsWithCategories.length).toBe(35);
+    it('should have 37 total tools', () => {
+      expect(allToolsWithCategories.length).toBe(37);
     });
   });
 
   describe('Filtering with profiles', () => {
-    it('full profile should return all 35 tools', () => {
+    it('full profile should return all 37 tools', () => {
       process.env.MCP_TOOLS_PROFILE = 'full';
       const config = loadToolsConfig();
       const filtered = filterEnabledTools(allToolsWithCategories, config);
-      expect(filtered.length).toBe(35);
+      expect(filtered.length).toBe(37);
     });
 
-    it('readonly profile should return only read and schema tools (15 total)', () => {
+    it('readonly profile should return only read and schema tools (17 total)', () => {
       process.env.MCP_TOOLS_PROFILE = 'readonly';
       const config = loadToolsConfig();
       const filtered = filterEnabledTools(allToolsWithCategories, config);
-      expect(filtered.length).toBe(15); // 13 read + 2 schema
+      expect(filtered.length).toBe(17); // 15 read + 2 schema
 
       // Verify specific tools
       const toolNames = filtered.map((t) => t.name);
@@ -172,17 +172,18 @@ describe('Tool Categories Integration', () => {
       expect(toolNames).toContain('search_vcons');
       expect(toolNames).toContain('vcon_fetch');
       expect(toolNames).toContain('vcon_capabilities');
+      expect(toolNames).toContain('vcon_graph_shape');
       expect(toolNames).toContain('vcon_search');
       expect(toolNames).toContain('get_schema');
       expect(toolNames).not.toContain('create_vcon');
       expect(toolNames).not.toContain('delete_vcon');
     });
 
-    it('user profile should return read, write, and schema tools (24 total)', () => {
+    it('user profile should return read, write, and schema tools (26 total)', () => {
       process.env.MCP_TOOLS_PROFILE = 'user';
       const config = loadToolsConfig();
       const filtered = filterEnabledTools(allToolsWithCategories, config);
-      expect(filtered.length).toBe(24); // 13 read + 9 write + 2 schema
+      expect(filtered.length).toBe(26); // 15 read + 9 write + 2 schema
 
       // Verify specific tools
       const toolNames = filtered.map((t) => t.name);
@@ -196,11 +197,11 @@ describe('Tool Categories Integration', () => {
       expect(toolNames).not.toContain('get_database_shape');
     });
 
-    it('admin profile should return read, analytics, infra, and schema tools (26 total)', () => {
+    it('admin profile should return read, analytics, infra, and schema tools (28 total)', () => {
       process.env.MCP_TOOLS_PROFILE = 'admin';
       const config = loadToolsConfig();
       const filtered = filterEnabledTools(allToolsWithCategories, config);
-      expect(filtered.length).toBe(26); // 13 read + 6 analytics + 5 infra + 2 schema
+      expect(filtered.length).toBe(28); // 15 read + 6 analytics + 5 infra + 2 schema
 
       // Verify specific tools
       const toolNames = filtered.map((t) => t.name);
@@ -214,11 +215,11 @@ describe('Tool Categories Integration', () => {
       expect(toolNames).not.toContain('delete_vcon');
     });
 
-    it('minimal profile should return only read and write tools (22 total)', () => {
+    it('minimal profile should return only read and write tools (24 total)', () => {
       process.env.MCP_TOOLS_PROFILE = 'minimal';
       const config = loadToolsConfig();
       const filtered = filterEnabledTools(allToolsWithCategories, config);
-      expect(filtered.length).toBe(22); // 13 read + 9 write
+      expect(filtered.length).toBe(24); // 15 read + 9 write
 
       // Verify specific tools
       const toolNames = filtered.map((t) => t.name);
@@ -240,7 +241,7 @@ describe('Tool Categories Integration', () => {
 
       const toolNames = filtered.map((t) => t.name);
       expect(toolNames).not.toContain('delete_vcon');
-      expect(filtered.length).toBe(34);
+      expect(filtered.length).toBe(36);
     });
 
     it('should disable multiple tools', () => {
@@ -252,7 +253,7 @@ describe('Tool Categories Integration', () => {
       expect(toolNames).not.toContain('delete_vcon');
       expect(toolNames).not.toContain('analyze_query');
       expect(toolNames).not.toContain('remove_all_tags');
-      expect(filtered.length).toBe(32);
+      expect(filtered.length).toBe(34);
     });
 
     it('should combine profile with disabled tools', () => {
@@ -264,7 +265,7 @@ describe('Tool Categories Integration', () => {
       const toolNames = filtered.map((t) => t.name);
       expect(toolNames).not.toContain('delete_vcon');
       expect(toolNames).not.toContain('get_database_analytics'); // Excluded by profile
-      expect(filtered.length).toBe(23); // 24 - 1 disabled
+      expect(filtered.length).toBe(25); // 26 - 1 disabled
     });
   });
 
@@ -274,7 +275,7 @@ describe('Tool Categories Integration', () => {
       const config = loadToolsConfig();
       const filtered = filterEnabledTools(allToolsWithCategories, config);
 
-      expect(filtered.length).toBe(15);
+      expect(filtered.length).toBe(17);
       filtered.forEach((tool) => {
         expect(['read', 'schema']).toContain(tool.category);
       });
@@ -285,7 +286,7 @@ describe('Tool Categories Integration', () => {
       const config = loadToolsConfig();
       const filtered = filterEnabledTools(allToolsWithCategories, config);
 
-      expect(filtered.length).toBe(24); // 35 - 6 analytics - 5 infra
+      expect(filtered.length).toBe(26); // 37 - 6 analytics - 5 infra
       filtered.forEach((tool) => {
         expect(['analytics', 'infra']).not.toContain(tool.category);
       });

--- a/tests/handlers/vcon-contract.test.ts
+++ b/tests/handlers/vcon-contract.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   VConFetchHandler,
   VConCapabilitiesHandler,
+  VConGraphShapeHandler,
   VConSearchHandler,
   VConTaxonomyHandler,
   DescribeResponseShapeHandler,
@@ -69,6 +70,13 @@ describe('Redesigned vCon contract handlers', () => {
       keywordSearchCount: vi.fn().mockResolvedValue(1),
       semanticSearch: vi.fn().mockResolvedValue([]),
       hybridSearch: vi.fn().mockResolvedValue([]),
+      getVconShapeGraph: vi.fn().mockResolvedValue({
+        schema_version: '1.0.0',
+        generated_at: '2026-05-11T14:00:00Z',
+        corpus: { notes: ['test'] },
+        nodes: [{ id: 'analysis_type:summary', kind: 'analysis_type', label: 'summary', vcon_count: 1 }],
+        edges: [],
+      }),
     };
 
     mockContext = {
@@ -188,10 +196,24 @@ describe('Redesigned vCon contract handlers', () => {
     expect(response.item.tools).toContain('vcon_fetch');
     expect(response.item.tools).toContain('vcon_search');
     expect(response.item.tools).toContain('vcon_capabilities');
+    expect(response.item.tools).toContain('vcon_graph_shape');
+    expect(response.item.shape_graph?.resource_uri).toBe('vcon://v1/graph/shape');
     expect(response.item.response_budgeting.default_max_response_bytes).toBe(250000);
     expect(response.item.fetch.supported_include).toContain('dealer');
     expect(response.item.search.modes).toContain('hybrid');
     expect(response.item.pagination.strategy).toBe('opaque cursor');
+  });
+
+  it('vcon_graph_shape returns shape graph payload', async () => {
+    const handler = new VConGraphShapeHandler();
+
+    const result = await handler.handle({}, mockContext);
+    const response = JSON.parse(result.content[0].text);
+
+    expect(response.ok).toBe(true);
+    expect(response.item.schema_version).toBe('1.0.0');
+    expect(response.item.nodes[0].kind).toBe('analysis_type');
+    expect(mockQueries.getVconShapeGraph).toHaveBeenCalled();
   });
 
   it('vcon_search returns a normalized metadata page', async () => {
@@ -273,6 +295,7 @@ describe('Redesigned vCon contract handlers', () => {
     expect(response.ok).toBe(true);
     expect(response.items.some((item: any) => item.tool_name === 'vcon_fetch')).toBe(true);
     expect(response.items.some((item: any) => item.tool_name === 'vcon_capabilities')).toBe(true);
+    expect(response.items.some((item: any) => item.tool_name === 'vcon_graph_shape')).toBe(true);
     expect(response.items.some((item: any) => item.tool_name === 'vcon_search')).toBe(true);
     expect(response.page.count).toBeGreaterThan(0);
   });

--- a/tests/new-tools-resources.test.ts
+++ b/tests/new-tools-resources.test.ts
@@ -49,7 +49,7 @@ describe('Resources Endpoint Tests', () => {
     it('should return all expected core resources', () => {
       const resources = getCoreResources();
 
-      expect(resources).toHaveLength(12);
+      expect(resources).toHaveLength(19);
       expect(resources.map(r => r.uri)).toEqual([
         'vcon://v1/vcons/recent',
         'vcon://v1/vcons/recent/ids',
@@ -60,6 +60,13 @@ describe('Resources Endpoint Tests', () => {
         'vcon://v1/vcons/{uuid}/dialog',
         'vcon://v1/vcons/{uuid}/analysis',
         'vcon://v1/vcons/{uuid}/attachments',
+        'vcon://v1/discovery/attachments/types',
+        'vcon://v1/discovery/attachments/purposes',
+        'vcon://v1/discovery/analysis/types',
+        'vcon://v1/graph/shape',
+        'vcon://v1/vcons/{uuid}/attachments/type/{type}',
+        'vcon://v1/vcons/{uuid}/attachments/purpose/{purpose}',
+        'vcon://v1/vcons/{uuid}/analysis/type/{type}',
         'vcon://v1/vcons/{uuid}/transcript',
         'vcon://v1/vcons/{uuid}/summary',
         'vcon://v1/vcons/{uuid}/tags',
@@ -149,6 +156,78 @@ describe('Resources Endpoint Tests', () => {
       expect(result).toBeDefined();
       expect(result?.content).toHaveProperty('count', 0);
       expect(result?.content.vcons).toHaveLength(0);
+    });
+  });
+
+  describe('resolveCoreResource - Discovery resources', () => {
+    it('should return attachment types with counts', async () => {
+      vi.spyOn(queries, 'getUniqueAttachmentTypes').mockResolvedValue({
+        values: ['document', 'tags'],
+        countsPerValue: { document: 3, tags: 1 },
+        totalVCons: 3,
+      });
+
+      const result = await resolveCoreResource(queries, 'vcon://v1/discovery/attachments/types');
+
+      expect(result?.content).toEqual({
+        count: 2,
+        attachment_types: [
+          { value: 'document', count: 3 },
+          { value: 'tags', count: 1 },
+        ],
+      });
+    });
+
+    it('should return attachment purposes with counts', async () => {
+      vi.spyOn(queries, 'getUniqueAttachmentPurposes').mockResolvedValue({
+        values: ['dealer_info'],
+        countsPerValue: { dealer_info: 2 },
+        totalVCons: 2,
+      });
+
+      const result = await resolveCoreResource(queries, 'vcon://v1/discovery/attachments/purposes');
+
+      expect(result?.content).toEqual({
+        count: 1,
+        attachment_purposes: [
+          { value: 'dealer_info', count: 2 },
+        ],
+      });
+    });
+
+    it('should return analysis types with counts', async () => {
+      vi.spyOn(queries, 'getUniqueAnalysisTypes').mockResolvedValue({
+        values: ['summary', 'transcript'],
+        countsPerValue: { summary: 5, transcript: 4 },
+        totalVCons: 6,
+      });
+
+      const result = await resolveCoreResource(queries, 'vcon://v1/discovery/analysis/types');
+
+      expect(result?.content).toEqual({
+        count: 2,
+        analysis_types: [
+          { value: 'summary', count: 5 },
+          { value: 'transcript', count: 4 },
+        ],
+      });
+    });
+
+    it('should return shape graph JSON', async () => {
+      const graphPayload = {
+        schema_version: '1.0.0',
+        generated_at: '2026-05-11T14:00:00Z',
+        corpus: { notes: [] },
+        nodes: [],
+        edges: [],
+      };
+      vi.spyOn(queries, 'getVconShapeGraph').mockResolvedValue(graphPayload as any);
+
+      const result = await resolveCoreResource(queries, 'vcon://v1/graph/shape');
+
+      expect(result?.mimeType).toBe('application/json');
+      expect(result?.content).toEqual(graphPayload);
+      expect(queries.getVconShapeGraph).toHaveBeenCalled();
     });
   });
 
@@ -486,8 +565,8 @@ describe('Resources Endpoint Tests', () => {
         { type: 'summary', vendor: 'TestVendor', body: 'Test summary' }
       ],
       attachments: [
-        { type: 'tags', encoding: 'json', body: '["key1:value1", "key2:value2"]' },
-        { type: 'document', filename: 'test.pdf' }
+        { type: 'tags', purpose: 'classification', encoding: 'json', body: '["key1:value1", "key2:value2"]' },
+        { type: 'document', purpose: 'dealer_info', filename: 'test.pdf' }
       ]
     };
 
@@ -535,6 +614,39 @@ describe('Resources Endpoint Tests', () => {
       expect(result?.mimeType).toBe('application/json');
       expect(result?.content).toHaveProperty('attachments');
       expect(result?.content.attachments).toHaveLength(2);
+    });
+
+    it('should return attachments filtered by type', async () => {
+      vi.spyOn(queries, 'getVCon').mockResolvedValue(mockVCon);
+
+      const result = await resolveCoreResource(queries, `vcon://v1/vcons/${testUuid}/attachments/type/document`);
+
+      expect(result?.content.count).toBe(1);
+      expect(result?.content.type).toBe('document');
+      expect(result?.content.attachments).toHaveLength(1);
+      expect(result?.content.attachments[0].type).toBe('document');
+    });
+
+    it('should return attachments filtered by purpose', async () => {
+      vi.spyOn(queries, 'getVCon').mockResolvedValue(mockVCon);
+
+      const result = await resolveCoreResource(queries, `vcon://v1/vcons/${testUuid}/attachments/purpose/dealer_info`);
+
+      expect(result?.content.count).toBe(1);
+      expect(result?.content.purpose).toBe('dealer_info');
+      expect(result?.content.attachments).toHaveLength(1);
+      expect(result?.content.attachments[0].purpose).toBe('dealer_info');
+    });
+
+    it('should return analysis filtered by type', async () => {
+      vi.spyOn(queries, 'getVCon').mockResolvedValue(mockVCon);
+
+      const result = await resolveCoreResource(queries, `vcon://v1/vcons/${testUuid}/analysis/type/summary`);
+
+      expect(result?.content.count).toBe(1);
+      expect(result?.content.type).toBe('summary');
+      expect(result?.content.analysis).toHaveLength(1);
+      expect(result?.content.analysis[0].type).toBe('summary');
     });
 
     it('should return empty arrays for missing subresources', async () => {
@@ -623,7 +735,7 @@ describe('Resources Endpoint Tests', () => {
         subject: 'Test vCon',
         parties: [],
         attachments: [
-          { type: 'tags', encoding: 'json', body: '["department:sales", "priority:high", "status:open"]' },
+          { type: 'tags', purpose: 'classification', encoding: 'json', body: '["department:sales", "priority:high", "status:open"]' },
           { type: 'document', filename: 'test.pdf' }
         ]
       };

--- a/tests/stress/full-coverage.test.ts
+++ b/tests/stress/full-coverage.test.ts
@@ -286,6 +286,8 @@ describe.skipIf(!runStress)('stress: full tool + resource coverage', () => {
     await readOk(`${base}/summary`);
     await readOk(`${base}/tags`);
 
+    await readOk('vcon://v1/graph/shape');
+
     // Prompts: get each
     for (const p of allPrompts) {
       const prompt = await ctx.client.getPrompt({

--- a/tests/tools/templates.test.ts
+++ b/tests/tools/templates.test.ts
@@ -46,7 +46,7 @@ describe('Templates', () => {
     it('should build phone_call template', () => {
       const vcon = buildTemplateVCon('phone_call', 'Test Call', mockParties);
 
-      expect(vcon.vcon).toBe('0.3.0');
+      expect(vcon.vcon).toBe('0.4.0');
       expect(vcon.uuid).toBeDefined();
       expect(vcon.created_at).toBeDefined();
       expect(vcon.subject).toBe('Test Call');
@@ -58,7 +58,7 @@ describe('Templates', () => {
     it('should build chat_conversation template', () => {
       const vcon = buildTemplateVCon('chat_conversation', 'Test Chat', mockParties);
 
-      expect(vcon.vcon).toBe('0.3.0');
+      expect(vcon.vcon).toBe('0.4.0');
       expect(vcon.subject).toBe('Test Chat');
       expect(vcon.parties).toEqual(mockParties);
       expect(vcon.dialog).toBeDefined();
@@ -68,7 +68,7 @@ describe('Templates', () => {
     it('should build email_thread template', () => {
       const vcon = buildTemplateVCon('email_thread', 'Test Email', mockParties);
 
-      expect(vcon.vcon).toBe('0.3.0');
+      expect(vcon.vcon).toBe('0.4.0');
       expect(vcon.subject).toBe('Test Email');
       expect(vcon.parties).toEqual(mockParties);
       expect(vcon.attachments).toBeDefined();
@@ -78,7 +78,7 @@ describe('Templates', () => {
     it('should build video_meeting template', () => {
       const vcon = buildTemplateVCon('video_meeting', 'Test Meeting', mockParties);
 
-      expect(vcon.vcon).toBe('0.3.0');
+      expect(vcon.vcon).toBe('0.4.0');
       expect(vcon.subject).toBe('Test Meeting');
       expect(vcon.parties).toEqual(mockParties);
       expect(vcon.dialog).toBeDefined();
@@ -88,7 +88,7 @@ describe('Templates', () => {
     it('should build custom template', () => {
       const vcon = buildTemplateVCon('custom', 'Test Custom', mockParties);
 
-      expect(vcon.vcon).toBe('0.3.0');
+      expect(vcon.vcon).toBe('0.4.0');
       expect(vcon.subject).toBe('Test Custom');
       expect(vcon.parties).toEqual(mockParties);
     });
@@ -96,7 +96,7 @@ describe('Templates', () => {
     it('should handle default/unknown template as custom', () => {
       const vcon = buildTemplateVCon('unknown_template' as any, 'Test', mockParties);
 
-      expect(vcon.vcon).toBe('0.3.0');
+      expect(vcon.vcon).toBe('0.4.0');
       expect(vcon.subject).toBe('Test');
       expect(vcon.parties).toEqual(mockParties);
     });


### PR DESCRIPTION
## Summary
- **`vcon_search` hardening for LLM clients** — tag-first pagination, dealer filter, and an aggregate RPC path (commit `e1bb129`). New migration `supabase/migrations/20250512180000_vcon_dealer_filter_and_aggregate.sql` ships the dealer-filter + aggregate RPCs.
- **Discovery + shape graph surface** — new discovery resources (`vcon://v1/discovery/attachments/purposes|types`, `vcon://v1/discovery/analysis/types`), OSS-safe shape graph at `vcon://v1/graph/shape` and matching `vcon_graph_shape` tool, with types in `src/types/vcon-shape-graph.ts` (commit `553d21b`).
- **Docs + tests aligned** — 37 files, +2916/-185 across queries, handlers, REST routes, resources, and tests; new docs under `docs/api/shape-graph-and-plugins.md` and `docs/examples/system-instruction-assets.md`.

## Test plan
- [ ] `npm run build`
- [ ] `npx vitest run`
- [ ] `npm run test:e2e` *(note: `search_vcons_content` describe block can exceed the 30 s default on large local corpora — a 120 s timeout bump is sitting locally and will be sent in a follow-up)*
- [ ] Inspector smoke: call `vcon_capabilities`, read `vcon://v1/graph/shape`, call `vcon_graph_shape`, then `vcon_search` in `metadata` and `keyword` modes
- [ ] Apply the new migration cleanly against a local Supabase: `supabase db push`

Generated with [Claude Code](https://claude.com/claude-code)