### PR TITLE
docs: refresh tag tools, CHANGELOG, legacy field names

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -361,7 +361,7 @@ interface ErrorResponse {
 
 ### API Version
 
-Current: **1.0.0**
+Current: **1.2.0**
 
 The API follows semantic versioning:
 - **Major** - Breaking changes

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -743,101 +743,103 @@ Combined keyword + semantic search for comprehensive results.
 
 ## Tag Management
 
-### add_tag
+The tag toolset was consolidated to 5 tools. Tags are stored as a
+special vCon attachment (`type: "tags"`, `encoding: "json"`, body is a
+JSON array of `"key:value"` strings).
 
-Add or update a single tag on a vCon.
+### manage_tag
+
+Add, update, or remove a single tag on a vCon. Replaces the older
+`add_tag`, `update_tags`, and `remove_tag` tools.
 
 **Input Parameters:**
 
 ```typescript
 {
-  vcon_uuid: string,      // vCon UUID (required)
-  key: string,            // Tag key (required)
-  value: string | number | boolean,  // Tag value (required)
-  overwrite?: boolean     // Default: true
+  vcon_uuid: string,                       // vCon UUID (required)
+  action: "set" | "remove",                // (required)
+  key: string,                             // Tag key (required)
+  value?: string | number | boolean        // Required when action="set"
 }
 ```
 
-**Response:**
+**Response (on success):**
 
 ```typescript
 {
-  success: boolean,
+  success: true,
   message: string,
+  action: "set" | "remove",
   key: string,
-  value: any
+  value?: string                            // Stringified, only when action="set"
 }
 ```
 
-**Example:**
+**Examples:**
 
 ```typescript
+// Set a tag
 {
   "vcon_uuid": "123e4567-e89b-12d3-a456-426614174000",
+  "action": "set",
   "key": "department",
   "value": "sales"
+}
+
+// Remove a tag
+{
+  "vcon_uuid": "123e4567-e89b-12d3-a456-426614174000",
+  "action": "remove",
+  "key": "department"
 }
 ```
 
 ---
 
-### get_tag
+### get_tags
 
-Retrieve a specific tag value.
+Retrieve tags from a vCon. Provide a specific `key` to get one tag, or
+omit `key` to get all tags. Replaces the older `get_tag` and
+`get_all_tags` tools.
 
 **Input Parameters:**
 
 ```typescript
 {
-  vcon_uuid: string,      // vCon UUID (required)
-  key: string,            // Tag key (required)
-  default_value?: any     // Return if tag doesn't exist
+  vcon_uuid: string,                                       // (required)
+  key?: string,                                            // Omit for all tags
+  default_value?: string | number | boolean | null         // Used when key is provided
 }
 ```
 
-**Response:**
+**Response — single tag (key provided):**
 
 ```typescript
 {
-  success: boolean,
+  success: true,
   key: string,
-  value: any,
+  value: string | number | boolean | null,
   exists: boolean
 }
 ```
 
----
-
-### get_all_tags
-
-Get all tags for a vCon.
-
-**Input Parameters:**
+**Response — all tags (key omitted):**
 
 ```typescript
 {
-  vcon_uuid: string       // vCon UUID (required)
-}
-```
-
-**Response:**
-
-```typescript
-{
-  success: boolean,
+  success: true,
   vcon_uuid: string,
-  tags: {
-    [key: string]: string | number | boolean
-  },
+  tags: { [key: string]: string },
   count: number
 }
 ```
 
-**Example Response:**
+**Example Response (all tags):**
 
 ```json
 {
   "success": true,
+  "vcon_uuid": "123e4567-e89b-12d3-a456-426614174000",
   "tags": {
     "department": "sales",
     "priority": "high",
@@ -850,16 +852,15 @@ Get all tags for a vCon.
 
 ---
 
-### remove_tag
+### remove_all_tags
 
-Remove a tag from a vCon.
+Remove all tags from a vCon.
 
 **Input Parameters:**
 
 ```typescript
 {
-  vcon_uuid: string,      // vCon UUID (required)
-  key: string             // Tag key to remove (required)
+  vcon_uuid: string                       // (required)
 }
 ```
 
@@ -867,18 +868,16 @@ Remove a tag from a vCon.
 
 ### search_by_tags
 
-Find vCons by tag criteria (all tags must match).
+Find vCons by tag criteria. All specified tags must match (AND logic).
 
 **Input Parameters:**
 
 ```typescript
 {
-  tags: {                 // Tag key-value pairs (required)
-    [key: string]: string
-  },
-  limit?: number,         // Default: 50, Max: 100 - Maximum number of UUIDs to return
-  return_full_vcons?: boolean,  // Default: auto (true for ≤20 results, false for >20)
-  max_full_vcons?: number      // Default: 20 - Max full vCon objects to return (prevents size limits)
+  tags: { [key: string]: string },        // Non-empty object (required)
+  limit?: number,                          // Default: 50, Max: 100
+  return_full_vcons?: boolean,             // Default: false for >20 results, true otherwise
+  max_full_vcons?: number                  // Default: 20, Max: 50
 }
 ```
 
@@ -886,20 +885,24 @@ Find vCons by tag criteria (all tags must match).
 
 ```typescript
 {
-  success: boolean,
+  success: true,
   count: number,
   tags_searched: object,
-  vcon_uuids: string[],   // Always returned (all matching UUIDs)
-  vcons?: VCon[],         // Only included if return_full_vcons=true
-  message?: string        // Helpful message about result size
+  vcon_uuids: string[],                    // All matching UUIDs (up to limit)
+  vcons?: VCon[],                          // Only when return_full_vcons=true
+  message?: string                          // Hint about result size
 }
 ```
 
 **Behavior:**
-- Always returns `vcon_uuids` for all matching vCons (up to `limit`)
-- For large result sets (>20), only UUIDs are returned by default to prevent response size limits
-- Use `return_full_vcons: true` to get full vCon objects (limited to `max_full_vcons` to prevent size issues)
-- For small result sets (≤20), full vCon objects are returned by default
+
+- Always returns `vcon_uuids` for matching vCons (up to `limit`).
+- For result sets > 20, only UUIDs are returned by default to keep the
+  response under MCP size limits.
+- Set `return_full_vcons: true` to receive full vCon objects (capped at
+  `max_full_vcons`).
+- The `tags` parameter must be a non-empty object; null, undefined, or
+  `{}` is rejected.
 
 **Example:**
 
@@ -918,15 +921,16 @@ Find vCons by tag criteria (all tags must match).
 
 ### get_unique_tags
 
-Discover all available tags across all vCons.
+Discover all unique tag keys and values across the database. Useful for
+building selection UIs and tag analytics.
 
 **Input Parameters:**
 
 ```typescript
 {
-  include_counts?: boolean,   // Include usage statistics
-  key_filter?: string,        // Filter by key substring
-  min_count?: number          // Minimum occurrence count
+  include_counts?: boolean,                // Include usage counts; default false
+  key_filter?: string,                     // Case-insensitive substring match on keys
+  min_count?: number                       // Minimum occurrence; default 1
 }
 ```
 
@@ -934,16 +938,14 @@ Discover all available tags across all vCons.
 
 ```typescript
 {
-  success: boolean,
+  success: true,
   unique_keys: string[],
   unique_key_count: number,
   tags_by_key: {
-    [key: string]: string[]   // All values for each key
+    [key: string]: string[]                // All distinct values per key
   },
-  counts_per_value?: {        // If include_counts=true
-    [key: string]: {
-      [value: string]: number
-    }
+  counts_per_value?: {                     // Only when include_counts=true
+    [key: string]: { [value: string]: number }
   },
   total_vcons_with_tags: number
 }
@@ -955,52 +957,6 @@ Discover all available tags across all vCons.
 {
   "include_counts": true,
   "key_filter": "department"
-}
-```
-
----
-
-### update_tags
-
-Update multiple tags at once.
-
-**Input Parameters:**
-
-```typescript
-{
-  vcon_uuid: string,      // vCon UUID (required)
-  tags: {                 // Tags to add/update (required)
-    [key: string]: string | number | boolean
-  },
-  merge?: boolean         // Merge with existing (true) or replace all (false)
-}
-```
-
-**Example:**
-
-```typescript
-{
-  "vcon_uuid": "123e4567-e89b-12d3-a456-426614174000",
-  "tags": {
-    "status": "closed",
-    "resolution": "resolved",
-    "resolved_at": "2025-10-14T15:30:00Z"
-  },
-  "merge": true
-}
-```
-
----
-
-### remove_all_tags
-
-Remove all tags from a vCon.
-
-**Input Parameters:**
-
-```typescript
-{
-  vcon_uuid: string       // vCon UUID (required)
 }
 ```
 

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -477,7 +477,7 @@ export interface VCon {
   vcon: VConVersion;
   uuid: string;
   extensions?: string[];      // Section 4.1.3
-  must_support?: string[];    // Section 4.1.4
+  critical?: string[];        // Section 4.1.4 (renamed from "must_support" in v0.4.0)
   created_at: string;
   updated_at?: string;
   subject?: string;
@@ -487,7 +487,7 @@ export interface VCon {
     url?: string;
     content_hash?: string | string[];
   };
-  appended?: {
+  amended?: {                 // Renamed from "appended" in v0.4.0
     uuid?: string;
     url?: string;
     content_hash?: string | string[];
@@ -575,7 +575,7 @@ export class VConQueries {
         created_at: vcon.created_at,
         updated_at: vcon.updated_at,
         extensions: vcon.extensions,
-        must_support: vcon.must_support,
+        critical: vcon.critical,
       })
       .select('id, uuid')
       .single();
@@ -687,7 +687,7 @@ export class VConQueries {
       vcon: vconData.vcon_version as '0.4.0',
       uuid: vconData.uuid,
       extensions: vconData.extensions,
-      must_support: vconData.must_support,
+      critical: vconData.critical,
       created_at: vconData.created_at,
       updated_at: vconData.updated_at,
       subject: vconData.subject,

--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -9,7 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.1] - 2025-01-XX
+## [1.2.0] - 2026-04-15
+
+### Added
+- REST API parity with MCP tool surface — full HTTP/JSON access at `/api/v1` (PR #46)
+- Predictable vCon contract tools: `vcon_fetch`, `vcon_search`, `vcon_capabilities`, `vcon_taxonomy`, `describe_response_shape`
+- HTTP transport (`MCP_TRANSPORT=http`) with Streamable HTTP and SSE
+- API-key authentication for REST and MCP HTTP endpoints (`API_KEYS`, `API_KEY_HEADER`, `API_AUTH_REQUIRED`)
+- Tool profiles and category controls (`MCP_TOOLS_PROFILE`, `MCP_ENABLED_CATEGORIES`, `MCP_DISABLED_CATEGORIES`, `MCP_DISABLED_TOOLS`)
+- Docker image published to `public.ecr.aws/r4g1k2s3/vcon-dev/vcon-mcp` with `main-<sha>`, `latest`, and semver tags
+- Build provenance exposed via `X-Version`, `X-Git-Commit`, `X-Build-Time` response headers
+- Pino structured JSON logging (stderr); OpenTelemetry instrumentation with OTLP exporter option
+- DNS rebinding protection options for HTTP transport (`MCP_HTTP_DNS_PROTECTION`, allowed hosts/origins)
+- Discovery surfaces and internal knowledge graph
+
+### Changed
+- Tool catalog grew from 30 to 35 (5 new contract tools)
+- vCon version handling relaxed to accept any string or missing value
+- Dialog disposition validation relaxed to accept any string
+- Bearer token extraction tolerates leading whitespace in headers
+
+### Fixed
+- Upsert vCon on duplicate UUID submission instead of erroring
+- Correct body serialization/deserialization for analysis and attachments (CON-352)
+- `getTags` no longer crashes on non-array attachment bodies
+
+---
+
+## [1.0.1] - 2025-12 (approximate)
+
+> Date precise to the month only — the npm-published 1.0.1 pre-dated the
+> current main lineage and its exact release date isn't in this repo.
 
 ### Added
 - Comprehensive database documentation for LLMs (architecture, quickstart, schema visual)
@@ -154,18 +184,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ✅ Reference documentation
 - ✅ VitePress site
 
-### Phase 4: Testing & Polish (In Progress)
-- ⏳ Comprehensive test suite
-- ⏳ Performance optimization
-- ⏳ Security audit
-- ⏳ Production hardening
+### Phase 4: Production & Distribution (Completed in 1.2.0)
+- ✅ REST API parity with MCP surface
+- ✅ HTTP transport with API-key auth
+- ✅ Docker image pipeline to ECR
+- ✅ Pino structured logging + OpenTelemetry
+- ✅ Multi-tenant RLS
 
-### Phase 5: Enterprise Features (Planned)
-- ⏳ Privacy Suite plugin
-- ⏳ Consent management
-- ⏳ Compliance tools (GDPR, CCPA, HIPAA)
-- ⏳ Access logging
-- ⏳ PII detection and redaction
+### Phase 5: Predictability & Discovery (Completed in 1.2.0)
+- ✅ Contract tools: `vcon_fetch`, `vcon_search`, `vcon_capabilities`, `vcon_taxonomy`, `describe_response_shape`
+- ✅ Discovery surfaces and internal knowledge graph
+
+### Phase 6: Future Work (Planned)
+- ⏳ Privacy Suite plugin (consent, redaction, PII detection)
+- ⏳ Compliance tooling hooks (GDPR, CCPA, HIPAA)
+- ⏳ Performance hardening on large corpora
 
 ---
 
@@ -246,23 +279,17 @@ This first major release represents a production-ready, fully spec-compliant vCo
 
 ## Future Roadmap
 
-### v1.1.0 (Planned)
-- Performance optimizations
-- Additional search features
-- Enhanced analytics
-- More prompt templates
+The roadmap below reflects work not yet started or in early planning.
+Concrete shipped versions live in the dated entries above.
 
-### v1.2.0 (Planned)
-- Real-time subscriptions
-- WebSocket support
-- GraphQL API option
-- Distributed tracing
+### Near-term (post-1.2.0)
+- Privacy Suite plugin (consent management, PII detection, redaction)
+- Compliance tooling hooks (GDPR, CCPA, HIPAA support patterns)
+- Performance hardening on large corpora (cold-start full-text search)
 
-### v2.0.0 (Future)
-- Multi-tenant architecture
-- Advanced security features
-- Cloud-native deployment
-- Horizontal scaling support
+### Longer-term
+- Cloud-native deployment patterns and horizontal scaling guidance
+- Additional storage backends
 
 ---
 
@@ -295,5 +322,5 @@ Privacy Suite and enterprise features are available under commercial license.
 
 ---
 
-*Last Updated: October 14, 2025*
+*Last Updated: May 18, 2026*
 


### PR DESCRIPTION
## Summary

Substantive doc refresh against current `main`:

- **Tag Management section in [docs/api/tools.md](docs/api/tools.md) rewritten.** Was documenting tools that no longer exist (`add_tag`, `get_tag`, `get_all_tags`, `remove_tag`, `update_tags`). Now matches the actual 5 handlers in [src/tools/handlers/tags.ts](src/tools/handlers/tags.ts) — `manage_tag`, `get_tags`, `remove_all_tags`, `search_by_tags`, `get_unique_tags` — with accurate input schemas and response shapes.
- **CHANGELOG entry added for 1.2.0** covering REST API parity (PR #46), predictable contract tools (`vcon_fetch`, `vcon_search`, `vcon_capabilities`, `vcon_taxonomy`, `describe_response_shape`), HTTP transport, API-key auth, Docker/ECR pipeline, Pino logging, OTel.
- **Roadmap section rewritten.** Old roadmap predicted 1.2.0 would deliver real-time subscriptions / WebSocket / GraphQL — none shipped. Replaced with honest near-term/longer-term sections.
- **Phase tracker updated.** Phase 4 moved from "in progress" to "completed in 1.2.0"; added Phase 5 (Predictability & Discovery) for the contract-tool work; renumbered Privacy Suite items to Phase 6.
- **1.0.1 date** changed from `2025-01-XX` placeholder to "2025-12 (approximate)" with note explaining the imprecision (that release pre-dates current main lineage).
- **\"Last Updated\" footer** bumped to 2026-05-18.
- **\"Current API Version: 1.0.0\"** in [docs/api/index.md:364](docs/api/index.md) → 1.2.0.
- **Legacy field names** in [docs/development/building.md](docs/development/building.md) (`must_support` → `critical`, `appended` → `amended`) per draft-ietf-vcon-vcon-core-02 / spec v0.4.0.

## Not in scope

- MongoDB docs banner/removal (decision needed; punted).
- Tool count refresh ("30" → "35" in 5 places) — already shipped in companion PR [#51](https://github.com/vcon-dev/vcon-mcp/pull/51).
- VCONIC reseller doc set — already shipped in companion PR [#50](https://github.com/vcon-dev/vcon-mcp/pull/50).
- Server hardcoded `version: '1.0.0'` in src/server/setup.ts:52 — code fix, separate PR.

## Test plan

- [x] \`npm run docs:build\` succeeds (16.14s, all pages render)
- [ ] Tag Management section reflects actual MCP tools when browsed at /api/tools
- [ ] CHANGELOG renders correctly with new 1.2.0 entry above 1.0.1
- [ ] No remaining \"add_tag\", \"get_all_tags\", \"update_tags\" tool references in docs/api/

🤖 Generated with [Claude Code](https://claude.com/claude-code)