### PR TITLE
supabase: fix enqueue_embedding trigger to use NEW.uuid

### DIFF
--- a/supabase/migrations/20260527220000_fix_enqueue_embedding_trigger.sql
+++ b/supabase/migrations/20260527220000_fix_enqueue_embedding_trigger.sql
@@ -1,0 +1,23 @@
+-- Fix enqueue_embedding trigger: insert NEW.uuid (not NEW.id)
+--
+-- The embedding_queue.vcon_id foreign key was changed in production from
+--   REFERENCES vcons(id)   -- as declared in 20251010140000
+-- to
+--   REFERENCES vcons(uuid)
+-- without a corresponding update to this trigger, which still inserted
+-- NEW.id. The result: every INSERT into vcons fired the trigger, the FK
+-- rejected the random gen_random_uuid() value (because nothing in vcons
+-- has that as its uuid column), and the whole transaction rolled back —
+-- silently blocking all new vcon row creation in production.
+--
+-- This migration aligns the trigger with the live FK target. NEW.uuid is
+-- the deterministic vCon UUID the rest of the system uses to identify
+-- vCons; that's what consumers (transcribe queue, analysis joins) already
+-- expect to find in embedding_queue.
+
+CREATE OR REPLACE FUNCTION enqueue_embedding() RETURNS trigger AS $$
+BEGIN
+  INSERT INTO embedding_queue(vcon_id) VALUES (NEW.uuid);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

The `embedding_queue.vcon_id` foreign key was changed in production from `REFERENCES vcons(id)` (as declared in `20251010140000_embedding_queue_and_trigger.sql`) to `REFERENCES vcons(uuid)`, but the `enqueue_embedding` trigger was never updated — it kept inserting `NEW.id` (the random `gen_random_uuid()` primary key) into a column whose FK now demands a value from `vcons.uuid`. Result: every INSERT into `vcons` fired the trigger, the FK rejected the random value, and the whole transaction rolled back — silently blocking **all new vCon row creation in production**.

## Live symptom (caught today, 2026-05-27)

- `MAX(created_at) FROM vcons` froze at `2026-05-27 13:50:54 UTC` and stayed there for ~6 h.
- `MAX(updated_at) FROM vcons` and `analysis.wtf_transcription` inserts kept ticking the whole time — because UPDATE doesn't fire `trg_enqueue_embedding`. That misled the initial diagnosis into thinking the persistence path was working.
- Customer impact: every new call FreeSWITCH recorded since 13:50 was discovered by the adapter, POSTed to conserver-api, and silently rolled back at this trigger.

## Repro

```sql
INSERT INTO vcons (id, uuid, vcon_version, subject)
VALUES (gen_random_uuid(), gen_random_uuid(), '0.3.0', 'fk-smoke');
-- ERROR: insert or update on table "embedding_queue" violates foreign key constraint "embedding_queue_vcon_id_fkey"
-- DETAIL: Key (vcon_id)=(<random uuid>) is not present in table "vcons".
-- CONTEXT: SQL statement "INSERT INTO embedding_queue(vcon_id) VALUES (NEW.id)"
```

## Fix

One-line swap: `NEW.id` → `NEW.uuid`. `NEW.uuid` is the deterministic vCon UUID the rest of the system already uses for identification; that's what every other join into `embedding_queue` will expect to find.

## Test plan

- [x] Applied to the live DB via direct DDL ~22:10 UTC. Smoke INSERT succeeded; matching `embedding_queue` row appeared.
- [x] Adapter is back to writing fresh vCons in production.
- [ ] Verify in CI on a fresh migration apply.

## Related (separate concern)

The other vCon FKs (`analysis`, `parties`, `dialog`, `attachments`, `groups`) also declare `REFERENCES vcons(id)` in their source migrations, but the **live DB has them all pointing at `vcons(uuid)`**. There's clearly a divergence between the migrations in this repo and the live schema. Worth a separate cleanup — flagged but not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)