### PR TITLE
fix(import): accumulate vCon file paths to avoid stack overflow

### DIFF
--- a/scripts/import-vcon-files.ts
+++ b/scripts/import-vcon-files.ts
@@ -118,11 +118,13 @@ function normaliseTagsBody(body: any): string {
 
 // ─── File discovery ───────────────────────────────────────────────────────────
 
-function findVConFiles(dir: string): string[] {
-  const results: string[] = [];
+function findVConFiles(dir: string, results: string[] = []): string[] {
+  // Accumulate into a shared array — spreading a recursive result into push()
+  // (`results.push(...findVConFiles(full))`) overflows the call stack on large
+  // corpora (hundreds of thousands of files).
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, e.name);
-    if (e.isDirectory()) results.push(...findVConFiles(full));
+    if (e.isDirectory()) findVConFiles(full, results);
     else if (e.isFile() && /\.(vcon|json)$/.test(e.name)) results.push(full);
   }
   return results;


### PR DESCRIPTION
## What

`findVConFiles` in `scripts/import-vcon-files.ts` spread each recursive
result into `push()`:

```ts
if (e.isDirectory()) results.push(...findVConFiles(full));
```

On large corpora (hundreds of thousands of files) the spread of a large
recursive result overflows the call stack. This passes a shared
accumulator array down the recursion instead, so each level appends in
place rather than spreading.

## Why

The Strolid import pipeline walks deep, wide directory trees
(`/Volumes/T9/test-vcons/strolid/YYYY/MM`). The spread form crashed on
real-world volumes.

## Change

- `findVConFiles(dir)` -> `findVConFiles(dir, results = [])`, recursing
  with the shared accumulator.

1 file changed, +5/-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)