### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.3.0] - 2026-06-10
+
+### Added
+- Per-group Supabase isolation: an instance is scoped by `SUPABASE_DB_SCHEMA` (default `public`), enabling one MCP server per group via a separate Supabase project (project isolation) or a separate Postgres schema in a shared project (schema isolation) (PR #58)
+- `ENV_FILE` support so each instance can load its own `.env.<group>` file
+- `VCON_INSTANCE_LABEL` surfaced in startup logs and `GET /api/v1/health` (alongside the active `schema`)
+- `start` / `start:group` npm scripts and `scripts/start-group.sh` launcher
+- `scripts/bootstrap-schema.sh` (clone `public` into a new schema, with pg version fallback, extension-type preservation, and role grants) and `scripts/migrate-all-groups.sh` (migration fan-out across groups)
+- Multi-Supabase Isolation guide; group-isolation env vars documented in installation/configuration/README
+
+### Changed
+- MCP server advertises its real package version (was hardcoded `1.0.0`); now sourced from `package.json`
+- The Supabase client applies `db.schema` from `SUPABASE_DB_SCHEMA`
+
+---
+
 ## [1.2.0] - 2026-04-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vcon-mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vcon-mcp",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.922.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vcon-mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "MCP Server for IETF vCon - Open Source Core",
   "type": "module",
   "main": "dist/index.js",

--- a/src/server/setup.ts
+++ b/src/server/setup.ts
@@ -4,6 +4,9 @@
  * Initializes database, plugins, and handler registry
  */
 
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { getRedisClient, getSupabaseClient } from '../db/client.js';
 // Supabase implementations
@@ -29,6 +32,22 @@ import { createHandlerRegistry, type ToolHandlerRegistry } from '../tools/handle
 
 const logger = createLogger('server-setup');
 
+/**
+ * Read the package version from package.json at runtime.
+ * Sourced here (not a compile-time JSON import) because rootDir is ./src,
+ * so package.json sits outside the TS root. From dist/server/setup.js the
+ * package root is ../../; the same holds in the published package and under
+ * vite-node (src/server) during tests.
+ */
+function getPackageVersion(): string {
+  try {
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'package.json');
+    return JSON.parse(readFileSync(pkgPath, 'utf8')).version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
 export interface ServerContext {
   server: Server;
   queries: IVConQueries;
@@ -49,7 +68,7 @@ export function createServer(): Server {
   return new Server(
     {
       name: 'vcon-mcp-server',
-      version: '1.0.0',
+      version: getPackageVersion(),
     },
     {
       capabilities: {


### PR DESCRIPTION
Release 1.3.0.

- Bump `package.json` 1.2.0 → 1.3.0
- MCP server now advertises its real package version (was hardcoded `1.0.0`); sourced from `package.json` at runtime (verified via stdio initialize: `serverInfo.version: 1.3.0`)
- CHANGELOG `[1.3.0]` entry covering per-group Supabase isolation (PR #58), `ENV_FILE`, `VCON_INSTANCE_LABEL`, the bootstrap/migrate/launcher scripts, and the multi-Supabase docs

Build green, 795 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)