### PR TITLE
Add dialog recording-archive locator columns

### DIFF
--- a/supabase/migrations/20260626000000_add_dialog_archive_columns.sql
+++ b/supabase/migrations/20260626000000_add_dialog_archive_columns.sql
@@ -1,0 +1,16 @@
+-- Migration: Add recording-archive locator columns to dialog
+--
+-- These point a dialog at its recording inside a compressed archive (e.g. a
+-- .tar.zst on a mounted filesystem or in S3): archive_url + byte offset/length
+-- locate a single zstd frame that decompresses to one Ogg-Opus file.
+-- archived_at is NULL until the recording has been committed to the archive.
+--
+-- These columns already exist on deployments where recording archival was
+-- enabled out-of-band; this formalizes them in the schema. Idempotent so it
+-- no-ops where they are already present.
+
+ALTER TABLE dialog ADD COLUMN IF NOT EXISTS archive_url TEXT;
+ALTER TABLE dialog ADD COLUMN IF NOT EXISTS archive_member TEXT;
+ALTER TABLE dialog ADD COLUMN IF NOT EXISTS archive_offset BIGINT;
+ALTER TABLE dialog ADD COLUMN IF NOT EXISTS archive_length BIGINT;
+ALTER TABLE dialog ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ;


### PR DESCRIPTION
## What

Adds five nullable columns to `dialog` that locate a call's recording inside a compressed archive:

| column | meaning |
|---|---|
| `archive_url` | path/URL of the archive (e.g. `/mnt/.../x.tar.zst` or `s3://...`) |
| `archive_member` | the member filename inside the archive (informational) |
| `archive_offset` | byte offset of that member's zstd frame |
| `archive_length` | byte length to read |
| `archived_at` | when archived (NULL ⇒ not yet archived) |

## Why

A search-app playback endpoint reads `[offset, offset+length)`, decompresses the one zstd frame, and serves Ogg-Opus on demand. These columns already exist out-of-band on a production database; this formalizes them in the schema so any vcon-mcp deployment is reproducible.

## Safety

Idempotent (`ADD COLUMN IF NOT EXISTS`) — no-ops where the columns already exist. All nullable, no backfill, no data movement. Consumers degrade gracefully where the columns are absent, so this is non-breaking and order-independent with any app rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)